### PR TITLE
Add manual monitoring checks and finalize worker registration

### DIFF
--- a/HRSDataIntegration.sln
+++ b/HRSDataIntegration.sln
@@ -37,6 +37,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HRSDataIntegration.HttpApi.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HRSDataIntegration.DbMigrator", "src\HRSDataIntegration.DbMigrator\HRSDataIntegration.DbMigrator.csproj", "{70680696-BB1E-4383-BCB2-42C3767171FB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Domain", "src\Monitoring.Domain\Monitoring.Domain.csproj", "{3638C207-D4F1-43EE-89C1-17EE542FA202}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Application.Contracts", "src\Monitoring.Application.Contracts\Monitoring.Application.Contracts.csproj", "{031AED1C-DC17-46A6-B4BF-42E6B1226E18}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Application", "src\Monitoring.Application\Monitoring.Application.csproj", "{3725357D-FC6A-4E7A-B461-88D7625D6773}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.HttpApi", "src\Monitoring.HttpApi\Monitoring.HttpApi.csproj", "{8CCE9872-9240-4BE4-B4FE-557F9E668144}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Web", "src\Monitoring.Web\Monitoring.Web.csproj", "{AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,9 +110,29 @@ Global
 		{EF480016-9127-4916-8735-D2466BDBC582}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF480016-9127-4916-8735-D2466BDBC582}.Release|Any CPU.Build.0 = Release|Any CPU
 		{70680696-BB1E-4383-BCB2-42C3767171FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{70680696-BB1E-4383-BCB2-42C3767171FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {70680696-BB1E-4383-BCB2-42C3767171FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3638C207-D4F1-43EE-89C1-17EE542FA202}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3638C207-D4F1-43EE-89C1-17EE542FA202}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3638C207-D4F1-43EE-89C1-17EE542FA202}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3638C207-D4F1-43EE-89C1-17EE542FA202}.Release|Any CPU.Build.0 = Release|Any CPU
+                {031AED1C-DC17-46A6-B4BF-42E6B1226E18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {031AED1C-DC17-46A6-B4BF-42E6B1226E18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {031AED1C-DC17-46A6-B4BF-42E6B1226E18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {031AED1C-DC17-46A6-B4BF-42E6B1226E18}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3725357D-FC6A-4E7A-B461-88D7625D6773}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3725357D-FC6A-4E7A-B461-88D7625D6773}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3725357D-FC6A-4E7A-B461-88D7625D6773}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3725357D-FC6A-4E7A-B461-88D7625D6773}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8CCE9872-9240-4BE4-B4FE-557F9E668144}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8CCE9872-9240-4BE4-B4FE-557F9E668144}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8CCE9872-9240-4BE4-B4FE-557F9E668144}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8CCE9872-9240-4BE4-B4FE-557F9E668144}.Release|Any CPU.Build.0 = Release|Any CPU
+                {AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,7 +152,12 @@ Global
 		{91853F21-9CD9-4132-BC29-A7D5D84FFFE7} = {04DBDB01-70F4-4E06-B468-8F87850B22BE}
 		{E512F4D9-9375-480F-A2F6-A46509F9D824} = {04DBDB01-70F4-4E06-B468-8F87850B22BE}
 		{EF480016-9127-4916-8735-D2466BDBC582} = {04DBDB01-70F4-4E06-B468-8F87850B22BE}
-		{70680696-BB1E-4383-BCB2-42C3767171FB} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {70680696-BB1E-4383-BCB2-42C3767171FB} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {3638C207-D4F1-43EE-89C1-17EE542FA202} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {031AED1C-DC17-46A6-B4BF-42E6B1226E18} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {3725357D-FC6A-4E7A-B461-88D7625D6773} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {8CCE9872-9240-4BE4-B4FE-557F9E668144} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
+                {AD1BDE6B-9566-4E14-AAB5-D45F4BC9E208} = {CA9AC87F-097E-4F15-8393-4BC07735A5B0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {28315BFD-90E7-4E14-A2EA-F3D23AF4126F}

--- a/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
@@ -284,6 +284,8 @@ public class HRSDataIntegrationDbContext :
             b.ToTable(MonitoringConsts.DbTablePrefix + "Outages", MonitoringConsts.DbSchema);
             b.ConfigureByConvention();
             b.Property(x => x.FailureCount).IsRequired();
+            b.Property(x => x.LastAlertAt);
+            b.Property(x => x.AlertsSent).HasDefaultValue(0);
             b.HasIndex(x => new { x.TargetId, x.StartedAt })
                 .HasDatabaseName("IX_Target_StartedAt")
                 .IsDescending(true, true);

--- a/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
@@ -64,6 +64,8 @@ public class HRSDataIntegrationDbContext :
 
     #region Monitoring
     public DbSet<MonitoringTarget> MonitoringTargets { get; set; }
+    public DbSet<ServiceStatusHistory> ServiceStatusHistories { get; set; }
+    public DbSet<OutageWindow> OutageWindows { get; set; }
     #endregion Monitoring
     #region Job
     public DbSet<Job> Job { get; set; }
@@ -228,7 +230,40 @@ public class HRSDataIntegrationDbContext :
             b.Property(x => x.Category).HasMaxLength(MonitoringTargetConsts.CategoryMaxLength);
             b.Property(x => x.CurrentStatus).HasConversion<int>();
             b.HasIndex(x => x.IsActive);
+            b.HasIndex(x => new { x.IsActive, x.NextDueAt })
+                .HasDatabaseName("IX_MonitoringTargets_IsActive_NextDueAt");
             b.HasQueryFilter(x => !x.IsDeleted);
+        });
+
+        builder.Entity<ServiceStatusHistory>(b =>
+        {
+            b.ToTable(MonitoringConsts.DbTablePrefix + "StatusHistory", MonitoringConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.FromStatus).HasConversion<int>();
+            b.Property(x => x.ToStatus).HasConversion<int>();
+            b.Property(x => x.TriggerSource).IsRequired().HasMaxLength(MonitoringHistoryConsts.TriggerSourceMaxLength);
+            b.Property(x => x.ErrorSummary).HasMaxLength(MonitoringHistoryConsts.ErrorSummaryMaxLength);
+            b.HasIndex(x => new { x.TargetId, x.ChangedAt })
+                .HasDatabaseName("IX_Target_ChangedAt")
+                .IsDescending(true, true);
+            b.HasOne<MonitoringTarget>()
+                .WithMany()
+                .HasForeignKey(x => x.TargetId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        builder.Entity<OutageWindow>(b =>
+        {
+            b.ToTable(MonitoringConsts.DbTablePrefix + "Outages", MonitoringConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.FailureCount).IsRequired();
+            b.HasIndex(x => new { x.TargetId, x.StartedAt })
+                .HasDatabaseName("IX_Target_StartedAt")
+                .IsDescending(true, true);
+            b.HasOne<MonitoringTarget>()
+                .WithMany()
+                .HasForeignKey(x => x.TargetId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
 

--- a/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
@@ -14,6 +14,8 @@ using Volo.Abp.SettingManagement.EntityFrameworkCore;
 using Volo.Abp.OpenIddict.EntityFrameworkCore;
 using Volo.Abp.TenantManagement;
 using Volo.Abp.TenantManagement.EntityFrameworkCore;
+using Monitoring;
+using Monitoring.Targets;
 using HRSDataIntegration.DTOs.Chart;
 using HRSDataIntegration.DTOs.Personeli;
 using HRSDataIntegration.DTOs;
@@ -59,6 +61,10 @@ public class HRSDataIntegrationDbContext :
     // Tenant Management
     public DbSet<Tenant> Tenants { get; set; }
     public DbSet<TenantConnectionString> TenantConnectionStrings { get; set; }
+
+    #region Monitoring
+    public DbSet<MonitoringTarget> MonitoringTargets { get; set; }
+    #endregion Monitoring
     #region Job
     public DbSet<Job> Job { get; set; }
     public DbSet<JobDetail> JobDetail { get; set; }
@@ -210,6 +216,20 @@ public class HRSDataIntegrationDbContext :
         .ToTable("OrganizationChartNodeDiagram", schema: "OrganChart");
         builder.Entity<OrganizationChartNodeDiagramPointArray>()
         .ToTable("OrganizationChartNodeDiagramPointArray", schema: "OrganChart");
+
+        builder.Entity<MonitoringTarget>(b =>
+        {
+            b.ToTable(MonitoringConsts.DbTablePrefix + "Targets", MonitoringConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.Name).IsRequired().HasMaxLength(MonitoringTargetConsts.NameMaxLength);
+            b.Property(x => x.Type).HasConversion<int>();
+            b.Property(x => x.Endpoint).IsRequired().HasMaxLength(MonitoringTargetConsts.EndpointMaxLength);
+            b.Property(x => x.SettingsJson).HasMaxLength(MonitoringTargetConsts.SettingsJsonMaxLength);
+            b.Property(x => x.Category).HasMaxLength(MonitoringTargetConsts.CategoryMaxLength);
+            b.Property(x => x.CurrentStatus).HasConversion<int>();
+            b.HasIndex(x => x.IsActive);
+            b.HasQueryFilter(x => !x.IsDeleted);
+        });
 
 
 

--- a/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/EntityFrameworkCore/HRSDataIntegrationDbContext.cs
@@ -64,6 +64,8 @@ public class HRSDataIntegrationDbContext :
 
     #region Monitoring
     public DbSet<MonitoringTarget> MonitoringTargets { get; set; }
+    public DbSet<AlertPolicy> MonitoringAlertPolicies { get; set; }
+    public DbSet<MaintenanceWindow> MonitoringMaintenanceWindows { get; set; }
     public DbSet<ServiceStatusHistory> ServiceStatusHistories { get; set; }
     public DbSet<OutageWindow> OutageWindows { get; set; }
     #endregion Monitoring
@@ -233,6 +235,31 @@ public class HRSDataIntegrationDbContext :
             b.HasIndex(x => new { x.IsActive, x.NextDueAt })
                 .HasDatabaseName("IX_MonitoringTargets_IsActive_NextDueAt");
             b.HasQueryFilter(x => !x.IsDeleted);
+        });
+
+        builder.Entity<AlertPolicy>(b =>
+        {
+            b.ToTable(MonitoringConsts.DbTablePrefix + "AlertPolicies", MonitoringConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.ChannelsJson).HasMaxLength(AlertPolicyConsts.ChannelsJsonMaxLength);
+            b.HasIndex(x => x.TargetId).IsUnique();
+            b.HasOne<MonitoringTarget>()
+                .WithOne()
+                .HasForeignKey<AlertPolicy>(x => x.TargetId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<MaintenanceWindow>(b =>
+        {
+            b.ToTable(MonitoringConsts.DbTablePrefix + "Maintenance", MonitoringConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.Reason).HasMaxLength(MaintenanceWindowConsts.ReasonMaxLength);
+            b.HasIndex(x => new { x.TargetId, x.StartUtc, x.EndUtc })
+                .HasDatabaseName("IX_Target_Start_End");
+            b.HasOne<MonitoringTarget>()
+                .WithMany()
+                .HasForeignKey(x => x.TargetId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         builder.Entity<ServiceStatusHistory>(b =>

--- a/src/HRSDataIntegration.EntityFrameworkCore/HRSDataIntegration.EntityFrameworkCore.csproj
+++ b/src/HRSDataIntegration.EntityFrameworkCore/HRSDataIntegration.EntityFrameworkCore.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\HRSDataIntegration.Application.Contracts\HRSDataIntegration.Application.Contracts.csproj" />
     <ProjectReference Include="..\HRSDataIntegration.Domain\HRSDataIntegration.Domain.csproj" />
+    <ProjectReference Include="..\Monitoring.Domain\Monitoring.Domain.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
@@ -1,0 +1,117 @@
+using System;
+using HRSDataIntegration.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace HRSDataIntegration.Migrations;
+
+[DbContext(typeof(HRSDataIntegrationDbContext))]
+partial class HRSDataIntegrationDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder
+            .HasAnnotation("ProductVersion", "8.0.4");
+
+        modelBuilder.Entity("Monitoring.Targets.MonitoringTarget", b =>
+        {
+            b.Property<Guid>("Id")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Category")
+                .HasMaxLength(100)
+                .HasColumnType("nvarchar(100)");
+
+            b.Property<int>("CheckIntervalSeconds")
+                .HasColumnType("int");
+
+            b.Property<int>("ConsecutiveFailures")
+                .HasColumnType("int");
+
+            b.Property<string>("ConcurrencyStamp")
+                .HasColumnType("nvarchar(40)")
+                .HasMaxLength(40);
+
+            b.Property<DateTime>("CreationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("CreatorId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<int>("CurrentStatus")
+                .HasColumnType("int");
+
+            b.Property<Guid?>("DeleterId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("DeletionTime")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Endpoint")
+                .IsRequired()
+                .HasMaxLength(512)
+                .HasColumnType("nvarchar(512)");
+
+            b.Property<string>("ExtraProperties")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<DateTime?>("FirstDownAt")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit")
+                .HasDefaultValue(false);
+
+            b.Property<DateTime?>("LastCheckedAt")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("LastModifierId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("LastModificationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime?>("LastStatusChangeAt")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime?>("LastUpAt")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("MaxRetryAttempts")
+                .HasColumnType("int");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasMaxLength(200)
+                .HasColumnType("nvarchar(200)");
+
+            b.Property<DateTime>("NextDueAt")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("RetryDelaySeconds")
+                .HasColumnType("int");
+
+            b.Property<string>("SettingsJson")
+                .HasMaxLength(4000)
+                .HasColumnType("nvarchar(4000)");
+
+            b.Property<int>("TimeoutSeconds")
+                .HasColumnType("int");
+
+            b.Property<int>("Type")
+                .HasColumnType("int");
+
+            b.HasKey("Id");
+
+            b.HasIndex("IsActive");
+
+            b.ToTable("MonitoringTargets", (string)null);
+        });
+    }
+}

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
@@ -246,6 +246,13 @@ partial class HRSDataIntegrationDbContextModelSnapshot : ModelSnapshot
             b.Property<int>("FailureCount")
                 .HasColumnType("int");
 
+            b.Property<int>("AlertsSent")
+                .HasColumnType("int")
+                .HasDefaultValue(0);
+
+            b.Property<DateTime?>("LastAlertAt")
+                .HasColumnType("datetime2");
+
             b.Property<DateTime>("StartedAt")
                 .HasColumnType("datetime2");
 

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/HRSDataIntegrationDbContextModelSnapshot.cs
@@ -116,6 +116,125 @@ partial class HRSDataIntegrationDbContextModelSnapshot : ModelSnapshot
             b.ToTable("MonitoringTargets", (string)null);
         });
 
+        modelBuilder.Entity("Monitoring.Targets.AlertPolicy", b =>
+        {
+            b.Property<Guid>("Id")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("ChannelsJson")
+                .HasMaxLength(4000)
+                .HasColumnType("nvarchar(4000)");
+
+            b.Property<string>("ConcurrencyStamp")
+                .HasColumnType("nvarchar(40)")
+                .HasMaxLength(40);
+
+            b.Property<DateTime>("CreationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("CreatorId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<Guid?>("DeleterId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("DeletionTime")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("Enabled")
+                .HasColumnType("bit");
+
+            b.Property<string>("ExtraProperties")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit")
+                .HasDefaultValue(false);
+
+            b.Property<DateTime?>("LastModificationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("LastModifierId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<int>("NotifyAfterFailures")
+                .HasColumnType("int");
+
+            b.Property<int>("RecoverQuietMinutes")
+                .HasColumnType("int");
+
+            b.Property<int>("RepeatMinutes")
+                .HasColumnType("int");
+
+            b.Property<bool>("SuppressDuringMaintenance")
+                .HasColumnType("bit");
+
+            b.Property<Guid>("TargetId")
+                .HasColumnType("uniqueidentifier");
+
+            b.HasKey("Id");
+
+            b.HasIndex("TargetId")
+                .IsUnique();
+
+            b.ToTable("MonitoringAlertPolicies", (string)null);
+        });
+
+        modelBuilder.Entity("Monitoring.Targets.MaintenanceWindow", b =>
+        {
+            b.Property<Guid>("Id")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("ConcurrencyStamp")
+                .HasColumnType("nvarchar(40)")
+                .HasMaxLength(40);
+
+            b.Property<DateTime>("CreationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("CreatorId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<Guid?>("DeleterId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("DeletionTime")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime>("EndUtc")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("ExtraProperties")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit")
+                .HasDefaultValue(false);
+
+            b.Property<DateTime?>("LastModificationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("LastModifierId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Reason")
+                .HasMaxLength(256)
+                .HasColumnType("nvarchar(256)");
+
+            b.Property<DateTime>("StartUtc")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("TargetId")
+                .HasColumnType("uniqueidentifier");
+
+            b.HasKey("Id");
+
+            b.HasIndex("TargetId", "StartUtc", "EndUtc")
+                .HasDatabaseName("IX_Target_Start_End");
+
+            b.ToTable("MonitoringMaintenance", (string)null);
+        });
+
         modelBuilder.Entity("Monitoring.Targets.OutageWindow", b =>
         {
             b.Property<Guid>("Id")
@@ -193,6 +312,23 @@ partial class HRSDataIntegrationDbContextModelSnapshot : ModelSnapshot
                 .HasForeignKey("TargetId")
                 .OnDelete(DeleteBehavior.Restrict)
                 .IsRequired();
+        });
+
+        modelBuilder.Entity("Monitoring.Targets.AlertPolicy", b =>
+        {
+            b.HasOne("Monitoring.Targets.MonitoringTarget", null)
+                .WithOne()
+                .HasForeignKey("Monitoring.Targets.AlertPolicy", "TargetId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
+        modelBuilder.Entity("Monitoring.Targets.MaintenanceWindow", b =>
+        {
+            b.HasOne("Monitoring.Targets.MonitoringTarget", null)
+                .WithMany()
+                .HasForeignKey("TargetId")
+                .OnDelete(DeleteBehavior.SetNull);
         });
     }
 }

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000000_Monitoring_Init.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000000_Monitoring_Init.cs
@@ -1,0 +1,169 @@
+using System;
+using HRSDataIntegration.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HRSDataIntegration.Migrations.Monitoring;
+
+[DbContext(typeof(HRSDataIntegrationDbContext))]
+[Migration("20240613000000_Monitoring_Init")]
+public partial class Monitoring_Init : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "MonitoringTargets",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                Type = table.Column<int>(type: "int", nullable: false),
+                Endpoint = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                SettingsJson = table.Column<string>(type: "nvarchar(4000)", maxLength: 4000, nullable: true),
+                CheckIntervalSeconds = table.Column<int>(type: "int", nullable: false),
+                TimeoutSeconds = table.Column<int>(type: "int", nullable: false),
+                MaxRetryAttempts = table.Column<int>(type: "int", nullable: false),
+                RetryDelaySeconds = table.Column<int>(type: "int", nullable: false),
+                Category = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                CurrentStatus = table.Column<int>(type: "int", nullable: false),
+                LastCheckedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LastStatusChangeAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                NextDueAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                ConsecutiveFailures = table.Column<int>(type: "int", nullable: false),
+                FirstDownAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LastUpAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: true),
+                CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MonitoringTargets", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_MonitoringTargets_IsActive",
+            table: "MonitoringTargets",
+            column: "IsActive");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "MonitoringTargets");
+    }
+
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder
+            .HasAnnotation("ProductVersion", "8.0.4");
+
+        modelBuilder.Entity("Monitoring.Targets.MonitoringTarget", b =>
+        {
+            b.Property<Guid>("Id")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Category")
+                .HasMaxLength(100)
+                .HasColumnType("nvarchar(100)");
+
+            b.Property<int>("CheckIntervalSeconds")
+                .HasColumnType("int");
+
+            b.Property<int>("ConsecutiveFailures")
+                .HasColumnType("int");
+
+            b.Property<string>("ConcurrencyStamp")
+                .HasColumnType("nvarchar(40)")
+                .HasMaxLength(40);
+
+            b.Property<DateTime>("CreationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("CreatorId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<int>("CurrentStatus")
+                .HasColumnType("int");
+
+            b.Property<Guid?>("DeleterId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("DeletionTime")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Endpoint")
+                .IsRequired()
+                .HasMaxLength(512)
+                .HasColumnType("nvarchar(512)");
+
+            b.Property<string>("ExtraProperties")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<DateTime?>("FirstDownAt")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<bool>("IsDeleted")
+                .HasColumnType("bit")
+                .HasDefaultValue(false);
+
+            b.Property<DateTime?>("LastCheckedAt")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid?>("LastModifierId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("LastModificationTime")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime?>("LastStatusChangeAt")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime?>("LastUpAt")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("MaxRetryAttempts")
+                .HasColumnType("int");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasMaxLength(200)
+                .HasColumnType("nvarchar(200)");
+
+            b.Property<DateTime>("NextDueAt")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("RetryDelaySeconds")
+                .HasColumnType("int");
+
+            b.Property<string>("SettingsJson")
+                .HasMaxLength(4000)
+                .HasColumnType("nvarchar(4000)");
+
+            b.Property<int>("TimeoutSeconds")
+                .HasColumnType("int");
+
+            b.Property<int>("Type")
+                .HasColumnType("int");
+
+            b.HasKey("Id");
+
+            b.HasIndex("IsActive");
+
+            b.ToTable("MonitoringTargets", (string)null);
+        });
+    }
+}

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000001_Monitoring_History_Init.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000001_Monitoring_History_Init.cs
@@ -2,16 +2,96 @@ using System;
 using HRSDataIntegration.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace HRSDataIntegration.Migrations;
+namespace HRSDataIntegration.Migrations.Monitoring;
 
 [DbContext(typeof(HRSDataIntegrationDbContext))]
-partial class HRSDataIntegrationDbContextModelSnapshot : ModelSnapshot
+[Migration("20240613000001_Monitoring_History_Init")]
+public partial class Monitoring_History_Init : Migration
 {
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "MonitoringStatusHistory",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                TargetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                FromStatus = table.Column<int>(type: "int", nullable: false),
+                ToStatus = table.Column<int>(type: "int", nullable: false),
+                ChangedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                TriggerSource = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                ResponseTimeMs = table.Column<int>(type: "int", nullable: true),
+                ErrorSummary = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MonitoringStatusHistory", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_MonitoringStatusHistory_MonitoringTargets_TargetId",
+                    column: x => x.TargetId,
+                    principalTable: "MonitoringTargets",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "MonitoringOutages",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                TargetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                StartedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                EndedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                FailureCount = table.Column<int>(type: "int", nullable: false),
+                TotalDurationSec = table.Column<int>(type: "int", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MonitoringOutages", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_MonitoringOutages_MonitoringTargets_TargetId",
+                    column: x => x.TargetId,
+                    principalTable: "MonitoringTargets",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Target_ChangedAt",
+            table: "MonitoringStatusHistory",
+            columns: new[] { "TargetId", "ChangedAt" },
+            descending: new[] { true, true });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Target_StartedAt",
+            table: "MonitoringOutages",
+            columns: new[] { "TargetId", "StartedAt" },
+            descending: new[] { true, true });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_MonitoringTargets_IsActive_NextDueAt",
+            table: "MonitoringTargets",
+            columns: new[] { "IsActive", "NextDueAt" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_MonitoringTargets_IsActive_NextDueAt",
+            table: "MonitoringTargets");
+
+        migrationBuilder.DropTable(
+            name: "MonitoringStatusHistory");
+
+        migrationBuilder.DropTable(
+            name: "MonitoringOutages");
+    }
+
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
         modelBuilder
             .HasAnnotation("ProductVersion", "8.0.4");

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000002_Monitoring_Alerts_Init.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000002_Monitoring_Alerts_Init.cs
@@ -1,0 +1,100 @@
+using System;
+using HRSDataIntegration.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HRSDataIntegration.Migrations.Monitoring;
+
+[DbContext(typeof(HRSDataIntegrationDbContext))]
+[Migration("20240613000002_Monitoring_Alerts_Init")]
+public partial class Monitoring_Alerts_Init : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "MonitoringAlertPolicies",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                TargetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Enabled = table.Column<bool>(type: "bit", nullable: false),
+                NotifyAfterFailures = table.Column<int>(type: "int", nullable: false),
+                RepeatMinutes = table.Column<int>(type: "int", nullable: false),
+                RecoverQuietMinutes = table.Column<int>(type: "int", nullable: false),
+                ChannelsJson = table.Column<string>(type: "nvarchar(4000)", maxLength: 4000, nullable: true),
+                SuppressDuringMaintenance = table.Column<bool>(type: "bit", nullable: false),
+                ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: true),
+                CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MonitoringAlertPolicies", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_MonitoringAlertPolicies_MonitoringTargets_TargetId",
+                    column: x => x.TargetId,
+                    principalTable: "MonitoringTargets",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "MonitoringMaintenance",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                TargetId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                StartUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                EndUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                Reason = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: true),
+                CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MonitoringMaintenance", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_MonitoringMaintenance_MonitoringTargets_TargetId",
+                    column: x => x.TargetId,
+                    principalTable: "MonitoringTargets",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_MonitoringAlertPolicies_TargetId",
+            table: "MonitoringAlertPolicies",
+            column: "TargetId",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Target_Start_End",
+            table: "MonitoringMaintenance",
+            columns: new[] { "TargetId", "StartUtc", "EndUtc" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "MonitoringAlertPolicies");
+
+        migrationBuilder.DropTable(
+            name: "MonitoringMaintenance");
+    }
+}

--- a/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000003_Monitoring_Alerts_ExtendOutage.cs
+++ b/src/HRSDataIntegration.EntityFrameworkCore/Migrations/Monitoring/20240613000003_Monitoring_Alerts_ExtendOutage.cs
@@ -1,0 +1,40 @@
+using System;
+using HRSDataIntegration.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HRSDataIntegration.Migrations.Monitoring;
+
+[DbContext(typeof(HRSDataIntegrationDbContext))]
+[Migration("20240613000003_Monitoring_Alerts_ExtendOutage")]
+public partial class Monitoring_Alerts_ExtendOutage : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "AlertsSent",
+            table: "MonitoringOutages",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "LastAlertAt",
+            table: "MonitoringOutages",
+            type: "datetime2",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "AlertsSent",
+            table: "MonitoringOutages");
+
+        migrationBuilder.DropColumn(
+            name: "LastAlertAt",
+            table: "MonitoringOutages");
+    }
+}

--- a/src/HRSDataIntegration.Web/HRSDataIntegration.Web.csproj
+++ b/src/HRSDataIntegration.Web/HRSDataIntegration.Web.csproj
@@ -62,6 +62,7 @@
     <ProjectReference Include="..\HRSDataIntegration.Application\HRSDataIntegration.Application.csproj" />
     <ProjectReference Include="..\HRSDataIntegration.HttpApi\HRSDataIntegration.HttpApi.csproj" />
     <ProjectReference Include="..\HRSDataIntegration.EntityFrameworkCore\HRSDataIntegration.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Monitoring.Web\Monitoring.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HRSDataIntegration.Web/HRSDataIntegrationWebModule.cs
+++ b/src/HRSDataIntegration.Web/HRSDataIntegrationWebModule.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Monitoring;
 using HRSDataIntegration.EntityFrameworkCore;
 using HRSDataIntegration.Localization;
 using HRSDataIntegration.MultiTenancy;
@@ -62,7 +63,8 @@ namespace HRSDataIntegration.Web;
     typeof(AbpAccountWebOpenIddictModule),
     typeof(AbpTenantManagementWebModule),
     typeof(AbpSwashbuckleModule),
-    typeof(AbpAspNetCoreSerilogModule)
+    typeof(AbpAspNetCoreSerilogModule),
+    typeof(MonitoringWebModule)
 )]
 public class HRSDataIntegrationWebModule : AbpModule
 {
@@ -79,7 +81,10 @@ public class HRSDataIntegrationWebModule : AbpModule
                 typeof(HRSDataIntegrationDomainSharedModule).Assembly,
                 typeof(HRSDataIntegrationApplicationModule).Assembly,
                 typeof(HRSDataIntegrationApplicationContractsModule).Assembly,
-                typeof(HRSDataIntegrationWebModule).Assembly
+                typeof(HRSDataIntegrationWebModule).Assembly,
+                typeof(MonitoringApplicationModule).Assembly,
+                typeof(MonitoringApplicationContractsModule).Assembly,
+                typeof(MonitoringWebModule).Assembly
             );
         });
 
@@ -217,6 +222,10 @@ public class HRSDataIntegrationWebModule : AbpModule
                 options.FileSets.ReplaceEmbeddedByPhysical<HRSDataIntegrationApplicationModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}HRSDataIntegration.Application", Path.DirectorySeparatorChar)));
                 options.FileSets.ReplaceEmbeddedByPhysical<HRSDataIntegrationHttpApiModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}..{0}src{0}HRSDataIntegration.HttpApi", Path.DirectorySeparatorChar)));
                 options.FileSets.ReplaceEmbeddedByPhysical<HRSDataIntegrationWebModule>(hostingEnvironment.ContentRootPath);
+                options.FileSets.ReplaceEmbeddedByPhysical<MonitoringApplicationContractsModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}Monitoring.Application.Contracts", Path.DirectorySeparatorChar)));
+                options.FileSets.ReplaceEmbeddedByPhysical<MonitoringApplicationModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}Monitoring.Application", Path.DirectorySeparatorChar)));
+                options.FileSets.ReplaceEmbeddedByPhysical<MonitoringHttpApiModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}Monitoring.HttpApi", Path.DirectorySeparatorChar)));
+                options.FileSets.ReplaceEmbeddedByPhysical<MonitoringWebModule>(Path.Combine(hostingEnvironment.ContentRootPath, string.Format("..{0}Monitoring.Web", Path.DirectorySeparatorChar)));
             }
         });
     }

--- a/src/Monitoring.Application.Contracts/Dashboard/DashboardIncidentDto.cs
+++ b/src/Monitoring.Application.Contracts/Dashboard/DashboardIncidentDto.cs
@@ -1,0 +1,17 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Dashboard;
+
+public class DashboardIncidentDto : EntityDto<Guid>
+{
+    public Guid TargetId { get; set; }
+
+    public DateTime StartedAt { get; set; }
+
+    public DateTime? EndedAt { get; set; }
+
+    public int FailureCount { get; set; }
+
+    public int? TotalDurationSec { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Dashboard/DashboardSummaryDto.cs
+++ b/src/Monitoring.Application.Contracts/Dashboard/DashboardSummaryDto.cs
@@ -1,0 +1,28 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Dashboard;
+
+public class DashboardSummaryDto : EntityDto<Guid>
+{
+    public int TotalTargets { get; set; }
+
+    public int OnlineCount { get; set; }
+
+    public int OfflineCount { get; set; }
+
+    public int CheckingCount { get; set; }
+
+    public double UptimePercentage { get; set; }
+
+    public int IncidentsCount { get; set; }
+
+    public DateTime RangeStart { get; set; }
+
+    public DateTime RangeEnd { get; set; }
+
+    public DashboardSummaryDto()
+    {
+        Id = Guid.Empty;
+    }
+}

--- a/src/Monitoring.Application.Contracts/Dashboard/IDashboardAppService.cs
+++ b/src/Monitoring.Application.Contracts/Dashboard/IDashboardAppService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+using Volo.Abp.Application.Services;
+
+namespace Monitoring.Dashboard;
+
+public interface IDashboardAppService : IApplicationService
+{
+    Task<DashboardSummaryDto> GetSummaryAsync(DateTime from, DateTime to, ServiceType? filterType = null);
+
+    Task<List<UptimeBucketDto>> GetUptimeSeriesAsync(Guid targetId, DateTime from, DateTime to, string bucket = "day");
+
+    Task<List<DashboardIncidentDto>> GetIncidentsAsync(Guid targetId, DateTime from, DateTime to, int skip = 0, int max = 100);
+
+    Task<MttrMtbfDto> GetReliabilityAsync(DateTime from, DateTime to, ServiceType? filterType = null);
+}

--- a/src/Monitoring.Application.Contracts/Dashboard/MttrMtbfDto.cs
+++ b/src/Monitoring.Application.Contracts/Dashboard/MttrMtbfDto.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Monitoring.Targets;
+
+namespace Monitoring.Dashboard;
+
+public class MttrMtbfDto
+{
+    public double? MeanTimeToRecoverSeconds { get; set; }
+
+    public double? MeanTimeBetweenFailuresSeconds { get; set; }
+
+    public List<MttrMtbfBreakdownDto> Breakdown { get; set; } = new();
+}
+
+public class MttrMtbfBreakdownDto
+{
+    public ServiceType ServiceType { get; set; }
+
+    public double? MeanTimeToRecoverSeconds { get; set; }
+
+    public double? MeanTimeBetweenFailuresSeconds { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Dashboard/UptimeBucketDto.cs
+++ b/src/Monitoring.Application.Contracts/Dashboard/UptimeBucketDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Monitoring.Dashboard;
+
+public class UptimeBucketDto
+{
+    public DateTime Start { get; set; }
+
+    public DateTime End { get; set; }
+
+    public double UptimePercentage { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Localization/MonitoringResource.cs
+++ b/src/Monitoring.Application.Contracts/Localization/MonitoringResource.cs
@@ -1,0 +1,8 @@
+using Volo.Abp.Localization;
+
+namespace Monitoring.Localization;
+
+[LocalizationResourceName("Monitoring")]
+public class MonitoringResource
+{
+}

--- a/src/Monitoring.Application.Contracts/Monitoring.Application.Contracts.csproj
+++ b/src/Monitoring.Application.Contracts/Monitoring.Application.Contracts.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\\..\\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.Ddd.Application.Contracts" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.Authorization" Version="8.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Monitoring.Domain\Monitoring.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Monitoring.Application.Contracts/MonitoringApplicationContractsModule.cs
+++ b/src/Monitoring.Application.Contracts/MonitoringApplicationContractsModule.cs
@@ -1,0 +1,22 @@
+using Monitoring.Localization;
+using Volo.Abp.Application;
+using Volo.Abp.Authorization;
+using Volo.Abp.Localization;
+using Volo.Abp.Modularity;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(AbpDddApplicationContractsModule),
+    typeof(AbpAuthorizationModule)
+    )]
+public class MonitoringApplicationContractsModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpLocalizationOptions>(options =>
+        {
+            options.Resources.Add<MonitoringResource>("en");
+        });
+    }
+}

--- a/src/Monitoring.Application.Contracts/Permissions/MonitoringPermissionDefinitionProvider.cs
+++ b/src/Monitoring.Application.Contracts/Permissions/MonitoringPermissionDefinitionProvider.cs
@@ -1,0 +1,26 @@
+using Monitoring.Localization;
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Localization;
+
+namespace Monitoring.Permissions;
+
+public class MonitoringPermissionDefinitionProvider : PermissionDefinitionProvider
+{
+    public override void Define(IPermissionDefinitionContext context)
+    {
+        var monitoringGroup = context.AddGroup(MonitoringPermissions.GroupName, L("Permission:Monitoring"));
+
+        var services = monitoringGroup.AddPermission(MonitoringPermissions.Services.Default, L("Permission:Monitoring.Services"));
+
+        services.AddChild(MonitoringPermissions.Services.View, L("Permission:Monitoring.Services.View"));
+        services.AddChild(MonitoringPermissions.Services.Create, L("Permission:Monitoring.Services.Create"));
+        services.AddChild(MonitoringPermissions.Services.Edit, L("Permission:Monitoring.Services.Edit"));
+        services.AddChild(MonitoringPermissions.Services.Delete, L("Permission:Monitoring.Services.Delete"));
+        services.AddChild(MonitoringPermissions.Services.Run, L("Permission:Monitoring.Services.Run"));
+    }
+
+    private static LocalizableString L(string name)
+    {
+        return LocalizableString.Create<MonitoringResource>(name);
+    }
+}

--- a/src/Monitoring.Application.Contracts/Permissions/MonitoringPermissions.cs
+++ b/src/Monitoring.Application.Contracts/Permissions/MonitoringPermissions.cs
@@ -1,0 +1,16 @@
+namespace Monitoring.Permissions;
+
+public static class MonitoringPermissions
+{
+    public const string GroupName = "Monitoring";
+
+    public static class Services
+    {
+        public const string Default = GroupName + ".Services";
+        public const string View = GroupName + ".Services.View";
+        public const string Create = GroupName + ".Services.Create";
+        public const string Edit = GroupName + ".Services.Edit";
+        public const string Delete = GroupName + ".Services.Delete";
+        public const string Run = GroupName + ".Services.Run";
+    }
+}

--- a/src/Monitoring.Application.Contracts/Targets/AlertPolicyDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/AlertPolicyDto.cs
@@ -1,0 +1,23 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Targets;
+
+public class AlertPolicyDto : EntityDto<Guid>
+{
+    public Guid TargetId { get; set; }
+
+    public bool Enabled { get; set; } = true;
+
+    public int NotifyAfterFailures { get; set; } = 1;
+
+    public int RepeatMinutes { get; set; } = 60;
+
+    public int RecoverQuietMinutes { get; set; } = 10;
+
+    public string? ChannelsJson { get; set; }
+
+    public bool SuppressDuringMaintenance { get; set; } = true;
+
+    public bool IsInherited { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/CreateUpdateMaintenanceWindowDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/CreateUpdateMaintenanceWindowDto.cs
@@ -1,0 +1,13 @@
+using System;
+namespace Monitoring.Targets;
+
+public class CreateUpdateMaintenanceWindowDto
+{
+    public Guid? TargetId { get; set; }
+
+    public DateTime StartUtc { get; set; }
+
+    public DateTime EndUtc { get; set; }
+
+    public string? Reason { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/CreateUpdateMonitoringTargetDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/CreateUpdateMonitoringTargetDto.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Monitoring.Targets;
@@ -6,7 +5,7 @@ namespace Monitoring.Targets;
 public class CreateUpdateMonitoringTargetDto
 {
     [Required]
-    [StringLength(200)]
+    [StringLength(128, MinimumLength = 2)]
     public string Name { get; set; } = string.Empty;
 
     [Required]
@@ -19,7 +18,7 @@ public class CreateUpdateMonitoringTargetDto
     [StringLength(4000)]
     public string? SettingsJson { get; set; }
 
-    [Range(1, int.MaxValue)]
+    [Range(10, int.MaxValue)]
     public int CheckIntervalSeconds { get; set; } = 300;
 
     [Range(1, int.MaxValue)]
@@ -28,27 +27,11 @@ public class CreateUpdateMonitoringTargetDto
     [Range(0, int.MaxValue)]
     public int MaxRetryAttempts { get; set; } = 3;
 
-    [Range(0, int.MaxValue)]
+    [Range(1, int.MaxValue)]
     public int RetryDelaySeconds { get; set; } = 30;
 
     [StringLength(100)]
     public string? Category { get; set; }
 
     public bool IsActive { get; set; } = true;
-
-    public ServiceStatus CurrentStatus { get; set; } = ServiceStatus.Checking;
-
-    public DateTime? LastCheckedAt { get; set; }
-
-    public DateTime? LastStatusChangeAt { get; set; }
-
-    [Required]
-    public DateTime NextDueAt { get; set; }
-
-    [Range(0, int.MaxValue)]
-    public int ConsecutiveFailures { get; set; } = 0;
-
-    public DateTime? FirstDownAt { get; set; }
-
-    public DateTime? LastUpAt { get; set; }
 }

--- a/src/Monitoring.Application.Contracts/Targets/CreateUpdateMonitoringTargetDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/CreateUpdateMonitoringTargetDto.cs
@@ -1,0 +1,54 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Monitoring.Targets;
+
+public class CreateUpdateMonitoringTargetDto
+{
+    [Required]
+    [StringLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public ServiceType Type { get; set; } = ServiceType.Website;
+
+    [Required]
+    [StringLength(512)]
+    public string Endpoint { get; set; } = string.Empty;
+
+    [StringLength(4000)]
+    public string? SettingsJson { get; set; }
+
+    [Range(1, int.MaxValue)]
+    public int CheckIntervalSeconds { get; set; } = 300;
+
+    [Range(1, int.MaxValue)]
+    public int TimeoutSeconds { get; set; } = 30;
+
+    [Range(0, int.MaxValue)]
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    [Range(0, int.MaxValue)]
+    public int RetryDelaySeconds { get; set; } = 30;
+
+    [StringLength(100)]
+    public string? Category { get; set; }
+
+    public bool IsActive { get; set; } = true;
+
+    public ServiceStatus CurrentStatus { get; set; } = ServiceStatus.Checking;
+
+    public DateTime? LastCheckedAt { get; set; }
+
+    public DateTime? LastStatusChangeAt { get; set; }
+
+    [Required]
+    public DateTime NextDueAt { get; set; }
+
+    [Range(0, int.MaxValue)]
+    public int ConsecutiveFailures { get; set; } = 0;
+
+    public DateTime? FirstDownAt { get; set; }
+
+    public DateTime? LastUpAt { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/HealthCheckResultDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/HealthCheckResultDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Monitoring.Targets;
+
+public class HealthCheckResultDto
+{
+    public Guid TargetId { get; set; }
+
+    public ServiceStatus Status { get; set; }
+
+    public int? ResponseTimeMs { get; set; }
+
+    public string? ErrorSummary { get; set; }
+
+    public DateTime CheckedAt { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
+++ b/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Application.Services;
+
+namespace Monitoring.Targets;
+
+public interface IMonitoringTargetAppService :
+    ICrudAppService<
+        MonitoringTargetDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        CreateUpdateMonitoringTargetDto>
+{
+    Task TriggerCheckAsync(Guid id);
+
+    Task<HealthCheckResultDto> CheckNowAsync(Guid id);
+
+    Task<List<HealthCheckResultDto>> CheckAllAsync();
+}

--- a/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
+++ b/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
@@ -6,13 +6,18 @@ using Volo.Abp.Application.Services;
 
 namespace Monitoring.Targets;
 
-public interface IMonitoringTargetAppService :
-    ICrudAppService<
-        MonitoringTargetDto,
-        Guid,
-        PagedAndSortedResultRequestDto,
-        CreateUpdateMonitoringTargetDto>
+public interface IMonitoringTargetAppService : IApplicationService
 {
+    Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(PagedAndSortedResultRequestDto input, ServiceType? type = null, string? search = null);
+
+    Task<MonitoringTargetDto> GetAsync(Guid id);
+
+    Task<MonitoringTargetDto> CreateAsync(CreateUpdateMonitoringTargetDto input);
+
+    Task<MonitoringTargetDto> UpdateAsync(Guid id, CreateUpdateMonitoringTargetDto input);
+
+    Task DeleteAsync(Guid id);
+
     Task TriggerCheckAsync(Guid id);
 
     Task<HealthCheckResultDto> CheckNowAsync(Guid id);

--- a/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
+++ b/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
@@ -18,4 +18,10 @@ public interface IMonitoringTargetAppService :
     Task<HealthCheckResultDto> CheckNowAsync(Guid id);
 
     Task<List<HealthCheckResultDto>> CheckAllAsync();
+
+    Task<int> CheckAllNowAsync();
+
+    Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10);
+
+    Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid targetId, int count = 20);
 }

--- a/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
+++ b/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
@@ -21,6 +21,8 @@ public interface IMonitoringTargetAppService :
 
     Task<int> CheckAllNowAsync();
 
+    Task<List<MonitoringTargetDto>> GetOverviewAsync(ServiceType? type = null);
+
     Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10);
 
     Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid targetId, int count = 20);

--- a/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
+++ b/src/Monitoring.Application.Contracts/Targets/IMonitoringTargetAppService.cs
@@ -31,4 +31,14 @@ public interface IMonitoringTargetAppService : IApplicationService
     Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10);
 
     Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid targetId, int count = 20);
+
+    Task<AlertPolicyDto> GetAlertPolicyAsync(Guid targetId);
+
+    Task<AlertPolicyDto> UpsertAlertPolicyAsync(Guid targetId, AlertPolicyDto input);
+
+    Task<List<MaintenanceWindowDto>> GetMaintenanceAsync(Guid? targetId = null);
+
+    Task<MaintenanceWindowDto> CreateMaintenanceAsync(CreateUpdateMaintenanceWindowDto input);
+
+    Task DeleteMaintenanceAsync(Guid id);
 }

--- a/src/Monitoring.Application.Contracts/Targets/MaintenanceWindowDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/MaintenanceWindowDto.cs
@@ -1,0 +1,15 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Targets;
+
+public class MaintenanceWindowDto : EntityDto<Guid>
+{
+    public Guid? TargetId { get; set; }
+
+    public DateTime StartUtc { get; set; }
+
+    public DateTime EndUtc { get; set; }
+
+    public string? Reason { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/MonitoringTargetDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/MonitoringTargetDto.cs
@@ -38,4 +38,6 @@ public class MonitoringTargetDto : FullAuditedEntityDto<Guid>
     public DateTime? FirstDownAt { get; set; }
 
     public DateTime? LastUpAt { get; set; }
+
+    public bool HasActiveMaintenance { get; set; }
 }

--- a/src/Monitoring.Application.Contracts/Targets/MonitoringTargetDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/MonitoringTargetDto.cs
@@ -1,0 +1,41 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Targets;
+
+public class MonitoringTargetDto : FullAuditedEntityDto<Guid>
+{
+    public string Name { get; set; } = string.Empty;
+
+    public ServiceType Type { get; set; }
+
+    public string Endpoint { get; set; } = string.Empty;
+
+    public string? SettingsJson { get; set; }
+
+    public int CheckIntervalSeconds { get; set; }
+
+    public int TimeoutSeconds { get; set; }
+
+    public int MaxRetryAttempts { get; set; }
+
+    public int RetryDelaySeconds { get; set; }
+
+    public string? Category { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public ServiceStatus CurrentStatus { get; set; }
+
+    public DateTime? LastCheckedAt { get; set; }
+
+    public DateTime? LastStatusChangeAt { get; set; }
+
+    public DateTime NextDueAt { get; set; }
+
+    public int ConsecutiveFailures { get; set; }
+
+    public DateTime? FirstDownAt { get; set; }
+
+    public DateTime? LastUpAt { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/OutageWindowDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/OutageWindowDto.cs
@@ -1,0 +1,13 @@
+using System;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Targets;
+
+public class OutageWindowDto : EntityDto<Guid>
+{
+    public Guid TargetId { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? EndedAt { get; set; }
+    public int FailureCount { get; set; }
+    public int? TotalDurationSec { get; set; }
+}

--- a/src/Monitoring.Application.Contracts/Targets/OutageWindowDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/OutageWindowDto.cs
@@ -10,4 +10,6 @@ public class OutageWindowDto : EntityDto<Guid>
     public DateTime? EndedAt { get; set; }
     public int FailureCount { get; set; }
     public int? TotalDurationSec { get; set; }
+    public DateTime? LastAlertAt { get; set; }
+    public int AlertsSent { get; set; }
 }

--- a/src/Monitoring.Application.Contracts/Targets/ServiceStatusHistoryDto.cs
+++ b/src/Monitoring.Application.Contracts/Targets/ServiceStatusHistoryDto.cs
@@ -1,0 +1,16 @@
+using System;
+using Monitoring.Targets;
+using Volo.Abp.Application.Dtos;
+
+namespace Monitoring.Targets;
+
+public class ServiceStatusHistoryDto : EntityDto<Guid>
+{
+    public Guid TargetId { get; set; }
+    public ServiceStatus FromStatus { get; set; }
+    public ServiceStatus ToStatus { get; set; }
+    public DateTime ChangedAt { get; set; }
+    public string TriggerSource { get; set; } = null!;
+    public int? ResponseTimeMs { get; set; }
+    public string? ErrorSummary { get; set; }
+}

--- a/src/Monitoring.Application/Alerts/AlertDispatch.cs
+++ b/src/Monitoring.Application/Alerts/AlertDispatch.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Monitoring.Alerts;
+
+internal sealed class AlertDispatch
+{
+    public AlertDispatch(
+        TargetSnapshot target,
+        AlertPayload payload,
+        IReadOnlyList<NotificationChannelDescriptor> channels)
+    {
+        Target = target;
+        Payload = payload;
+        Channels = channels;
+    }
+
+    public TargetSnapshot Target { get; }
+    public AlertPayload Payload { get; }
+    public IReadOnlyList<NotificationChannelDescriptor> Channels { get; }
+}

--- a/src/Monitoring.Application/Alerts/AlertEvaluator.cs
+++ b/src/Monitoring.Application/Alerts/AlertEvaluator.cs
@@ -23,7 +23,7 @@ internal static class AlertEvaluator
             {
                 if (input.ConsecutiveFailures >= input.NotifyAfterFailures)
                 {
-                    return new AlertEvaluationResult(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
+                    return AlertEvaluationResult.From(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
                 }
 
                 return AlertEvaluationResult.None;
@@ -39,7 +39,7 @@ internal static class AlertEvaluator
                 // This covers the case when retries delayed the first alert.
                 if (input.ConsecutiveFailures >= input.NotifyAfterFailures)
                 {
-                    return new AlertEvaluationResult(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
+                    return AlertEvaluationResult.From(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
                 }
 
                 return AlertEvaluationResult.None;
@@ -48,7 +48,7 @@ internal static class AlertEvaluator
             var nextAllowed = input.ActiveOutage.LastAlertAt.Value.AddMinutes(input.RepeatMinutes);
             if (input.Timestamp >= nextAllowed)
             {
-                return new AlertEvaluationResult(AlertEventType.StillDown, input.ActiveOutage, shouldRecordAlert: true);
+                return AlertEvaluationResult.From(AlertEventType.StillDown, input.ActiveOutage, shouldRecordAlert: true);
             }
 
             return AlertEvaluationResult.None;
@@ -58,19 +58,19 @@ internal static class AlertEvaluator
         {
             if (input.RecoverQuietMinutes <= 0)
             {
-                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+                return AlertEvaluationResult.From(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
             }
 
             var lastUp = input.PreviousLastUpAt;
             if (!lastUp.HasValue)
             {
-                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+                return AlertEvaluationResult.From(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
             }
 
             var quietThreshold = lastUp.Value.AddMinutes(input.RecoverQuietMinutes);
             if (input.Timestamp >= quietThreshold)
             {
-                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+                return AlertEvaluationResult.From(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
             }
         }
 
@@ -135,10 +135,8 @@ internal readonly struct AlertEvaluationResult
     public OutageWindow? Outage { get; }
     public bool ShouldRecordAlert { get; }
 
-    public static AlertEvaluationResult None => new(null, null, false);
+    public static AlertEvaluationResult None { get; } = new(null, null, false);
 
-    public AlertEvaluationResult(AlertEventType eventType, OutageWindow? outage, bool shouldRecordAlert)
-        : this(eventType, outage, shouldRecordAlert)
-    {
-    }
+    public static AlertEvaluationResult From(AlertEventType eventType, OutageWindow? outage, bool shouldRecordAlert)
+        => new(eventType, outage, shouldRecordAlert);
 }

--- a/src/Monitoring.Application/Alerts/AlertEvaluator.cs
+++ b/src/Monitoring.Application/Alerts/AlertEvaluator.cs
@@ -1,0 +1,144 @@
+using System;
+using Monitoring.Targets;
+
+namespace Monitoring.Alerts;
+
+internal static class AlertEvaluator
+{
+    public static AlertEvaluationResult Evaluate(AlertEvaluationInput input)
+    {
+        if (!input.Enabled)
+        {
+            return AlertEvaluationResult.None;
+        }
+
+        if (input.UnderMaintenance)
+        {
+            return AlertEvaluationResult.None;
+        }
+
+        if (input.CurrentStatus == ServiceStatus.Offline)
+        {
+            if (input.PreviousStatus != ServiceStatus.Offline)
+            {
+                if (input.ConsecutiveFailures >= input.NotifyAfterFailures)
+                {
+                    return new AlertEvaluationResult(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
+                }
+
+                return AlertEvaluationResult.None;
+            }
+
+            if (input.ActiveOutage == null)
+            {
+                return AlertEvaluationResult.None;
+            }
+
+            if (!input.ActiveOutage.LastAlertAt.HasValue)
+            {
+                // This covers the case when retries delayed the first alert.
+                if (input.ConsecutiveFailures >= input.NotifyAfterFailures)
+                {
+                    return new AlertEvaluationResult(AlertEventType.Down, input.ActiveOutage, shouldRecordAlert: true);
+                }
+
+                return AlertEvaluationResult.None;
+            }
+
+            var nextAllowed = input.ActiveOutage.LastAlertAt.Value.AddMinutes(input.RepeatMinutes);
+            if (input.Timestamp >= nextAllowed)
+            {
+                return new AlertEvaluationResult(AlertEventType.StillDown, input.ActiveOutage, shouldRecordAlert: true);
+            }
+
+            return AlertEvaluationResult.None;
+        }
+
+        if (input.PreviousStatus == ServiceStatus.Offline && input.CurrentStatus == ServiceStatus.Online)
+        {
+            if (input.RecoverQuietMinutes <= 0)
+            {
+                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+            }
+
+            var lastUp = input.PreviousLastUpAt;
+            if (!lastUp.HasValue)
+            {
+                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+            }
+
+            var quietThreshold = lastUp.Value.AddMinutes(input.RecoverQuietMinutes);
+            if (input.Timestamp >= quietThreshold)
+            {
+                return new AlertEvaluationResult(AlertEventType.Recovered, input.ClosedOutage, shouldRecordAlert: false);
+            }
+        }
+
+        return AlertEvaluationResult.None;
+    }
+}
+
+internal readonly struct AlertEvaluationInput
+{
+    public AlertEvaluationInput(
+        ServiceStatus previousStatus,
+        ServiceStatus currentStatus,
+        int consecutiveFailures,
+        DateTime timestamp,
+        int notifyAfterFailures,
+        int repeatMinutes,
+        int recoverQuietMinutes,
+        bool enabled,
+        bool underMaintenance,
+        OutageWindow? activeOutage,
+        OutageWindow? closedOutage,
+        DateTime? previousLastUpAt)
+    {
+        PreviousStatus = previousStatus;
+        CurrentStatus = currentStatus;
+        ConsecutiveFailures = consecutiveFailures;
+        Timestamp = timestamp;
+        NotifyAfterFailures = notifyAfterFailures;
+        RepeatMinutes = repeatMinutes;
+        RecoverQuietMinutes = recoverQuietMinutes;
+        Enabled = enabled;
+        UnderMaintenance = underMaintenance;
+        ActiveOutage = activeOutage;
+        ClosedOutage = closedOutage;
+        PreviousLastUpAt = previousLastUpAt;
+    }
+
+    public ServiceStatus PreviousStatus { get; }
+    public ServiceStatus CurrentStatus { get; }
+    public int ConsecutiveFailures { get; }
+    public DateTime Timestamp { get; }
+    public int NotifyAfterFailures { get; }
+    public int RepeatMinutes { get; }
+    public int RecoverQuietMinutes { get; }
+    public bool Enabled { get; }
+    public bool UnderMaintenance { get; }
+    public OutageWindow? ActiveOutage { get; }
+    public OutageWindow? ClosedOutage { get; }
+    public DateTime? PreviousLastUpAt { get; }
+}
+
+internal readonly struct AlertEvaluationResult
+{
+    private AlertEvaluationResult(AlertEventType? eventType, OutageWindow? outage, bool shouldRecordAlert)
+    {
+        EventType = eventType;
+        Outage = outage;
+        ShouldRecordAlert = shouldRecordAlert;
+    }
+
+    public AlertEventType? EventType { get; }
+    public OutageWindow? Outage { get; }
+    public bool ShouldRecordAlert { get; }
+
+    public static AlertEvaluationResult None => new(null, null, false);
+
+    public AlertEvaluationResult(AlertEventType eventType, OutageWindow? outage, bool shouldRecordAlert)
+        : this(eventType, outage, shouldRecordAlert)
+    {
+    }
+}

--- a/src/Monitoring.Application/Alerts/AlertModels.cs
+++ b/src/Monitoring.Application/Alerts/AlertModels.cs
@@ -1,0 +1,95 @@
+using System;
+using Monitoring.Targets;
+
+namespace Monitoring.Alerts;
+
+public enum AlertEventType
+{
+    Down,
+    StillDown,
+    Recovered
+}
+
+public sealed class TargetSnapshot
+{
+    public TargetSnapshot(
+        Guid targetId,
+        string name,
+        ServiceType type,
+        string endpoint,
+        ServiceStatus status,
+        DateTime? lastCheckedAt,
+        DateTime? lastStatusChangeAt,
+        DateTime? firstDownAt,
+        DateTime? lastUpAt,
+        string? category)
+    {
+        TargetId = targetId;
+        Name = name;
+        Type = type;
+        Endpoint = endpoint;
+        Status = status;
+        LastCheckedAt = lastCheckedAt;
+        LastStatusChangeAt = lastStatusChangeAt;
+        FirstDownAt = firstDownAt;
+        LastUpAt = lastUpAt;
+        Category = category;
+    }
+
+    public Guid TargetId { get; }
+    public string Name { get; }
+    public ServiceType Type { get; }
+    public string Endpoint { get; }
+    public ServiceStatus Status { get; }
+    public DateTime? LastCheckedAt { get; }
+    public DateTime? LastStatusChangeAt { get; }
+    public DateTime? FirstDownAt { get; }
+    public DateTime? LastUpAt { get; }
+    public string? Category { get; }
+}
+
+public sealed class AlertPayload
+{
+    public AlertPayload(
+        AlertEventType eventType,
+        DateTime eventAt,
+        string? errorSummary,
+        int? responseTimeMs,
+        OutageSnapshot? currentOutage)
+    {
+        EventType = eventType;
+        EventAt = eventAt;
+        ErrorSummary = errorSummary;
+        ResponseTimeMs = responseTimeMs;
+        CurrentOutage = currentOutage;
+    }
+
+    public AlertEventType EventType { get; }
+    public DateTime EventAt { get; }
+    public string? ErrorSummary { get; }
+    public int? ResponseTimeMs { get; }
+    public OutageSnapshot? CurrentOutage { get; }
+}
+
+public sealed class OutageSnapshot
+{
+    public OutageSnapshot(
+        Guid outageId,
+        DateTime startedAt,
+        DateTime? endedAt,
+        int failureCount,
+        int? totalDurationSec)
+    {
+        OutageId = outageId;
+        StartedAt = startedAt;
+        EndedAt = endedAt;
+        FailureCount = failureCount;
+        TotalDurationSec = totalDurationSec;
+    }
+
+    public Guid OutageId { get; }
+    public DateTime StartedAt { get; }
+    public DateTime? EndedAt { get; }
+    public int FailureCount { get; }
+    public int? TotalDurationSec { get; }
+}

--- a/src/Monitoring.Application/Alerts/EmailNotificationChannel.cs
+++ b/src/Monitoring.Application/Alerts/EmailNotificationChannel.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Volo.Abp;
+using Volo.Abp.Emailing;
+
+namespace Monitoring.Alerts;
+
+public sealed class EmailNotificationChannel : INotificationChannel
+{
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<EmailNotificationChannel> _logger;
+    private readonly IReadOnlyList<string> _recipients;
+    private readonly string? _fromAddress;
+    private readonly string _subjectPrefix;
+
+    public EmailNotificationChannel(
+        IEmailSender emailSender,
+        ILogger<EmailNotificationChannel> logger,
+        IReadOnlyList<string> recipients,
+        string? fromAddress,
+        string subjectPrefix)
+    {
+        _emailSender = emailSender;
+        _logger = logger;
+        _recipients = recipients;
+        _fromAddress = fromAddress;
+        _subjectPrefix = subjectPrefix ?? string.Empty;
+    }
+
+    public async Task SendAsync(TargetSnapshot target, AlertPayload payload, CancellationToken cancellationToken)
+    {
+        if (_recipients.Count == 0)
+        {
+            _logger.LogDebug("Skipping email notification for target {TargetId} because no recipients were configured.", target.TargetId);
+            return;
+        }
+
+        var subject = BuildSubject(payload.EventType, target.Name);
+        var body = BuildBody(target, payload);
+
+        foreach (var recipient in _recipients)
+        {
+            if (recipient.IsNullOrWhiteSpace())
+            {
+                continue;
+            }
+
+            try
+            {
+                if (_fromAddress.IsNullOrWhiteSpace())
+                {
+                    await _emailSender.SendAsync(recipient, subject, body);
+                }
+                else
+                {
+                    await _emailSender.SendAsync(new EmailMessage(
+                        fromAddress: _fromAddress!,
+                        to: recipient,
+                        subject: subject,
+                        body: body));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to send email notification for target {TargetId} to configured recipient.", target.TargetId);
+            }
+        }
+    }
+
+    private string BuildSubject(AlertEventType eventType, string targetName)
+    {
+        var normalizedPrefix = string.IsNullOrWhiteSpace(_subjectPrefix) ? string.Empty : _subjectPrefix.Trim();
+        var separator = normalizedPrefix.Length > 0 ? " " : string.Empty;
+        return string.Concat(normalizedPrefix, separator, eventType.ToString(), " alert for ", targetName);
+    }
+
+    private static string BuildBody(TargetSnapshot target, AlertPayload payload)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Alert Type: {payload.EventType}");
+        builder.AppendLine($"Service: {target.Name} ({target.Type})");
+        builder.AppendLine($"Endpoint: {target.Endpoint}");
+        builder.AppendLine($"Occurred At: {payload.EventAt:O}");
+
+        if (payload.ResponseTimeMs.HasValue)
+        {
+            builder.AppendLine($"Response Time: {payload.ResponseTimeMs.Value} ms");
+        }
+
+        if (!payload.ErrorSummary.IsNullOrWhiteSpace())
+        {
+            builder.AppendLine($"Error: {payload.ErrorSummary}");
+        }
+
+        if (payload.CurrentOutage != null)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Outage Summary:");
+            builder.AppendLine($"  Started: {payload.CurrentOutage.StartedAt:O}");
+            if (payload.CurrentOutage.EndedAt.HasValue)
+            {
+                builder.AppendLine($"  Ended: {payload.CurrentOutage.EndedAt.Value:O}");
+            }
+            builder.AppendLine($"  Failures: {payload.CurrentOutage.FailureCount}");
+            if (payload.CurrentOutage.TotalDurationSec.HasValue)
+            {
+                builder.AppendLine($"  Duration: {TimeSpan.FromSeconds(Math.Max(payload.CurrentOutage.TotalDurationSec.Value, 0))}");
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Monitoring.Application/Alerts/EmailNotificationChannel.cs
+++ b/src/Monitoring.Application/Alerts/EmailNotificationChannel.cs
@@ -14,20 +14,17 @@ public sealed class EmailNotificationChannel : INotificationChannel
     private readonly IEmailSender _emailSender;
     private readonly ILogger<EmailNotificationChannel> _logger;
     private readonly IReadOnlyList<string> _recipients;
-    private readonly string? _fromAddress;
     private readonly string _subjectPrefix;
 
     public EmailNotificationChannel(
         IEmailSender emailSender,
         ILogger<EmailNotificationChannel> logger,
         IReadOnlyList<string> recipients,
-        string? fromAddress,
         string subjectPrefix)
     {
         _emailSender = emailSender;
         _logger = logger;
         _recipients = recipients;
-        _fromAddress = fromAddress;
         _subjectPrefix = subjectPrefix ?? string.Empty;
     }
 
@@ -51,18 +48,7 @@ public sealed class EmailNotificationChannel : INotificationChannel
 
             try
             {
-                if (_fromAddress.IsNullOrWhiteSpace())
-                {
-                    await _emailSender.SendAsync(recipient, subject, body);
-                }
-                else
-                {
-                    await _emailSender.SendAsync(new EmailMessage(
-                        fromAddress: _fromAddress!,
-                        to: recipient,
-                        subject: subject,
-                        body: body));
-                }
+                await _emailSender.SendAsync(recipient, subject, body);
             }
             catch (Exception ex)
             {

--- a/src/Monitoring.Application/Alerts/NotificationChannelResolver.cs
+++ b/src/Monitoring.Application/Alerts/NotificationChannelResolver.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp;
+using Volo.Abp.Emailing;
+using Monitoring.Options;
+
+namespace Monitoring.Alerts;
+
+public sealed class NotificationChannelResolver : INotificationChannelResolver
+{
+    private static readonly JsonSerializerOptions ChannelsSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IEmailSender _emailSender;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly MonitoringOptions _options;
+
+    public NotificationChannelResolver(
+        IEmailSender emailSender,
+        IHttpClientFactory httpClientFactory,
+        ILoggerFactory loggerFactory,
+        IOptions<MonitoringOptions> options)
+    {
+        _emailSender = emailSender;
+        _httpClientFactory = httpClientFactory;
+        _loggerFactory = loggerFactory;
+        _options = options.Value;
+    }
+
+    public IReadOnlyList<NotificationChannelDescriptor> ResolveChannels(AlertChannelConfiguration configuration)
+    {
+        var channels = new List<NotificationChannelDescriptor>();
+        if (configuration?.Channels == null || configuration.Channels.Count == 0)
+        {
+            return channels;
+        }
+
+        foreach (var kvp in configuration.Channels)
+        {
+            var key = kvp.Key?.Trim();
+            if (key.IsNullOrWhiteSpace())
+            {
+                continue;
+            }
+
+            var entries = (kvp.Value ?? Array.Empty<string>()).Where(x => !x.IsNullOrWhiteSpace())
+                .Select(x => x.Trim())
+                .Where(x => !x.IsNullOrWhiteSpace())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (entries.Length == 0)
+            {
+                continue;
+            }
+
+            switch (key.ToLowerInvariant())
+            {
+                case "email":
+                    channels.Add(CreateEmailChannel(entries));
+                    break;
+                case "webhook":
+                    channels.Add(CreateWebhookChannel(entries));
+                    break;
+                case "telegram":
+                    channels.Add(CreateTelegramChannel(entries));
+                    break;
+            }
+        }
+
+        return channels;
+    }
+
+    public static Dictionary<string, string[]> ParseChannelsJson(string? channelsJson)
+    {
+        if (channelsJson.IsNullOrWhiteSpace())
+        {
+            return new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            var dictionary = JsonSerializer.Deserialize<Dictionary<string, string[]>>(channelsJson!, ChannelsSerializerOptions);
+            return dictionary == null
+                ? new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string[]>(dictionary, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private NotificationChannelDescriptor CreateEmailChannel(IReadOnlyList<string> recipients)
+    {
+        var logger = _loggerFactory.CreateLogger<EmailNotificationChannel>();
+        var channel = new EmailNotificationChannel(
+            _emailSender,
+            logger,
+            recipients,
+            _options.Notifications.Email.FromAddress,
+            _options.Notifications.Email.SubjectPrefix ?? string.Empty);
+
+        return new NotificationChannelDescriptor("email", channel);
+    }
+
+    private NotificationChannelDescriptor CreateWebhookChannel(IReadOnlyList<string> endpoints)
+    {
+        var logger = _loggerFactory.CreateLogger<WebhookNotificationChannel>();
+        var headers = _options.Notifications.Webhook.DefaultHeaders ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var channel = new WebhookNotificationChannel(
+            _httpClientFactory,
+            logger,
+            endpoints,
+            headers);
+
+        return new NotificationChannelDescriptor("webhook", channel);
+    }
+
+    private NotificationChannelDescriptor CreateTelegramChannel(IReadOnlyList<string> chatIds)
+    {
+        var logger = _loggerFactory.CreateLogger<TelegramNotificationChannel>();
+        var effectiveChatIds = chatIds.Count > 0
+            ? chatIds
+            : _options.Notifications.Telegram.ChatIds ?? Array.Empty<string>();
+
+        var channel = new TelegramNotificationChannel(
+            _httpClientFactory,
+            logger,
+            _options.Notifications.Telegram.BotToken ?? string.Empty,
+            effectiveChatIds);
+
+        return new NotificationChannelDescriptor("telegram", channel);
+    }
+}

--- a/src/Monitoring.Application/Alerts/NotificationChannelResolver.cs
+++ b/src/Monitoring.Application/Alerts/NotificationChannelResolver.cs
@@ -106,7 +106,6 @@ public sealed class NotificationChannelResolver : INotificationChannelResolver
             _emailSender,
             logger,
             recipients,
-            _options.Notifications.Email.FromAddress,
             _options.Notifications.Email.SubjectPrefix ?? string.Empty);
 
         return new NotificationChannelDescriptor("email", channel);

--- a/src/Monitoring.Application/Alerts/NotificationChannels.cs
+++ b/src/Monitoring.Application/Alerts/NotificationChannels.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Monitoring.Alerts;
+
+public interface INotificationChannel
+{
+    Task SendAsync(TargetSnapshot target, AlertPayload payload, CancellationToken cancellationToken);
+}
+
+public interface INotificationChannelResolver
+{
+    IReadOnlyList<NotificationChannelDescriptor> ResolveChannels(AlertChannelConfiguration configuration);
+}
+
+public sealed record NotificationChannelDescriptor(string Name, INotificationChannel Channel);
+
+public sealed class AlertChannelConfiguration
+{
+    public AlertChannelConfiguration(Dictionary<string, string[]> channels)
+    {
+        Channels = channels == null
+            ? new Dictionary<string, string[]>(System.StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string[]>(channels, System.StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Dictionary<string, string[]> Channels { get; }
+}

--- a/src/Monitoring.Application/Alerts/TelegramNotificationChannel.cs
+++ b/src/Monitoring.Application/Alerts/TelegramNotificationChannel.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Monitoring.Alerts;
+
+public sealed class TelegramNotificationChannel : INotificationChannel
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TelegramNotificationChannel> _logger;
+    private readonly string _botToken;
+    private readonly IReadOnlyList<string> _chatIds;
+
+    public TelegramNotificationChannel(
+        IHttpClientFactory httpClientFactory,
+        ILogger<TelegramNotificationChannel> logger,
+        string botToken,
+        IReadOnlyList<string> chatIds)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _botToken = botToken;
+        _chatIds = chatIds;
+    }
+
+    public async Task SendAsync(TargetSnapshot target, AlertPayload payload, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_botToken) || _chatIds.Count == 0)
+        {
+            _logger.LogDebug("Skipping Telegram notification for target {TargetId} due to missing configuration.", target.TargetId);
+            return;
+        }
+
+        var message = BuildMessage(target, payload);
+        var client = _httpClientFactory.CreateClient("Monitoring.Telegram");
+
+        foreach (var chatId in _chatIds)
+        {
+            if (string.IsNullOrWhiteSpace(chatId))
+            {
+                continue;
+            }
+
+            try
+            {
+                var requestUri = $"https://api.telegram.org/bot{_botToken}/sendMessage";
+                using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["chat_id"] = chatId,
+                    ["text"] = message,
+                    ["parse_mode"] = "MarkdownV2"
+                });
+
+                using var response = await client.PostAsync(requestUri, content, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning(
+                        "Telegram notification returned non-success status {Status} for target {TargetId}.",
+                        (int)response.StatusCode,
+                        target.TargetId);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Telegram notification failed for target {TargetId}.", target.TargetId);
+            }
+        }
+    }
+
+    private static string BuildMessage(TargetSnapshot target, AlertPayload payload)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"*{EscapeMarkdown(target.Name)}* - {payload.EventType}");
+        builder.AppendLine($"Endpoint: `{EscapeMarkdown(target.Endpoint)}`");
+        builder.AppendLine($"Status: {payload.EventType} at {payload.EventAt:O}");
+
+        if (!string.IsNullOrWhiteSpace(payload.ErrorSummary))
+        {
+            builder.AppendLine($"Error: {EscapeMarkdown(payload.ErrorSummary!)}");
+        }
+
+        if (payload.ResponseTimeMs.HasValue)
+        {
+            builder.AppendLine($"Response: {payload.ResponseTimeMs.Value} ms");
+        }
+
+        if (payload.CurrentOutage != null)
+        {
+            builder.AppendLine($"Outage started: {payload.CurrentOutage.StartedAt:O}");
+            if (payload.CurrentOutage.EndedAt.HasValue)
+            {
+                builder.AppendLine($"Outage ended: {payload.CurrentOutage.EndedAt.Value:O}");
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeMarkdown(string value)
+    {
+        var builder = new StringBuilder(value.Length * 2);
+        foreach (var ch in value)
+        {
+            if ("_[]()~`>#+-=|{}.!".IndexOf(ch) >= 0)
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Monitoring.Application/Alerts/WebhookNotificationChannel.cs
+++ b/src/Monitoring.Application/Alerts/WebhookNotificationChannel.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Monitoring.Alerts;
+
+public sealed class WebhookNotificationChannel : INotificationChannel
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<WebhookNotificationChannel> _logger;
+    private readonly IReadOnlyList<string> _endpoints;
+    private readonly IReadOnlyDictionary<string, string> _defaultHeaders;
+
+    public WebhookNotificationChannel(
+        IHttpClientFactory httpClientFactory,
+        ILogger<WebhookNotificationChannel> logger,
+        IReadOnlyList<string> endpoints,
+        IReadOnlyDictionary<string, string> defaultHeaders)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _endpoints = endpoints;
+        _defaultHeaders = defaultHeaders;
+    }
+
+    public async Task SendAsync(TargetSnapshot target, AlertPayload payload, CancellationToken cancellationToken)
+    {
+        if (_endpoints.Count == 0)
+        {
+            _logger.LogDebug("Skipping webhook notification for target {TargetId} because no endpoints were configured.", target.TargetId);
+            return;
+        }
+
+        var body = BuildPayload(target, payload);
+
+        foreach (var endpoint in _endpoints)
+        {
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                };
+
+                foreach (var header in _defaultHeaders)
+                {
+                    if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                    {
+                        request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var client = _httpClientFactory.CreateClient("Monitoring.Webhooks");
+                using var response = await client.SendAsync(request, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning(
+                        "Webhook notification returned non-success status {Status} for target {TargetId}.",
+                        (int)response.StatusCode,
+                        target.TargetId);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Webhook notification failed for target {TargetId}.", target.TargetId);
+            }
+        }
+    }
+
+    private static string BuildPayload(TargetSnapshot target, AlertPayload payload)
+    {
+        var document = new
+        {
+            eventType = payload.EventType.ToString(),
+            eventAt = payload.EventAt,
+            target = new
+            {
+                id = target.TargetId,
+                name = target.Name,
+                type = target.Type.ToString(),
+                endpoint = target.Endpoint,
+                status = target.Status.ToString(),
+                category = target.Category,
+                lastCheckedAt = target.LastCheckedAt,
+                lastStatusChangeAt = target.LastStatusChangeAt,
+                firstDownAt = target.FirstDownAt,
+                lastUpAt = target.LastUpAt
+            },
+            details = new
+            {
+                errorSummary = payload.ErrorSummary,
+                responseTimeMs = payload.ResponseTimeMs,
+                outage = payload.CurrentOutage == null
+                    ? null
+                    : new
+                    {
+                        id = payload.CurrentOutage.OutageId,
+                        startedAt = payload.CurrentOutage.StartedAt,
+                        endedAt = payload.CurrentOutage.EndedAt,
+                        failureCount = payload.CurrentOutage.FailureCount,
+                        totalDurationSec = payload.CurrentOutage.TotalDurationSec
+                    }
+            }
+        };
+
+        return JsonSerializer.Serialize(document, SerializerOptions);
+    }
+}

--- a/src/Monitoring.Application/AssemblyInfo.cs
+++ b/src/Monitoring.Application/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HRSDataIntegration.Application.Tests")]

--- a/src/Monitoring.Application/Dashboard/DashboardAppService.cs
+++ b/src/Monitoring.Application/Dashboard/DashboardAppService.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Monitoring.Dashboard;
+using Monitoring.Options;
+using Monitoring.Permissions;
+using Monitoring.Targets;
+using Volo.Abp;
+using Volo.Abp.Application.Services;
+using Volo.Abp.Authorization;
+using Volo.Abp.Domain.Repositories;
+
+namespace Monitoring.Dashboard;
+
+public class DashboardAppService : ApplicationService, IDashboardAppService
+{
+    private const int DefaultIncidentPageSize = 50;
+
+    private readonly IRepository<MonitoringTarget, Guid> _targetRepository;
+    private readonly IRepository<OutageWindow, Guid> _outageRepository;
+    private readonly MonitoringOptions _options;
+
+    public DashboardAppService(
+        IRepository<MonitoringTarget, Guid> targetRepository,
+        IRepository<OutageWindow, Guid> outageRepository,
+        IOptions<MonitoringOptions> options)
+    {
+        _targetRepository = targetRepository;
+        _outageRepository = outageRepository;
+        _options = options.Value;
+    }
+
+    public async Task<DashboardSummaryDto> GetSummaryAsync(DateTime from, DateTime to, ServiceType? filterType = null)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+        var (rangeStart, rangeEnd) = NormalizeRange(from, to);
+
+        var targetQuery = await _targetRepository.GetQueryableAsync();
+        if (filterType.HasValue)
+        {
+            targetQuery = targetQuery.Where(t => t.Type == filterType.Value);
+        }
+
+        var targetSnapshots = await AsyncExecuter.ToListAsync(
+            targetQuery.Select(t => new
+            {
+                t.Id,
+                t.Type,
+                t.CurrentStatus
+            }));
+
+        var totalTargets = targetSnapshots.Count;
+
+        var result = new DashboardSummaryDto
+        {
+            TotalTargets = totalTargets,
+            OnlineCount = targetSnapshots.Count(t => t.CurrentStatus == ServiceStatus.Online),
+            OfflineCount = targetSnapshots.Count(t => t.CurrentStatus == ServiceStatus.Offline),
+            CheckingCount = targetSnapshots.Count(t => t.CurrentStatus == ServiceStatus.Checking),
+            RangeStart = rangeStart,
+            RangeEnd = rangeEnd
+        };
+
+        if (totalTargets == 0)
+        {
+            result.UptimePercentage = 100;
+            result.IncidentsCount = 0;
+            return result;
+        }
+
+        var targetIds = targetSnapshots.Select(t => t.Id).ToList();
+        var outages = await LoadOutagesAsync(targetIds, rangeStart, rangeEnd);
+
+        var rangeSeconds = (rangeEnd - rangeStart).TotalSeconds;
+        if (rangeSeconds <= 0)
+        {
+            result.UptimePercentage = 100;
+            result.IncidentsCount = outages.Count;
+            return result;
+        }
+
+        var downtimeSeconds = outages.Sum(outage => DashboardMetricsHelper.CalculateOverlapSeconds(outage, rangeStart, rangeEnd));
+        var denominator = rangeSeconds * totalTargets;
+        var uptime = denominator <= 0 ? 1 : Math.Clamp(1 - (downtimeSeconds / denominator), 0, 1);
+        result.UptimePercentage = Math.Round(uptime * 100, 2);
+        result.IncidentsCount = outages.Count;
+        return result;
+    }
+
+    public async Task<List<UptimeBucketDto>> GetUptimeSeriesAsync(Guid targetId, DateTime from, DateTime to, string bucket = "day")
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+        var (rangeStart, rangeEnd) = NormalizeRange(from, to);
+
+        var bucketLength = ResolveBucketLength(bucket);
+        var outages = await LoadOutagesAsync(new List<Guid> { targetId }, rangeStart, rangeEnd);
+
+        var buckets = new List<UptimeBucketDto>();
+        var cursor = rangeStart;
+        while (cursor < rangeEnd)
+        {
+            var bucketEnd = cursor.Add(bucketLength);
+            if (bucketEnd > rangeEnd)
+            {
+                bucketEnd = rangeEnd;
+            }
+
+            var bucketDuration = (bucketEnd - cursor).TotalSeconds;
+            double uptimePct = 100;
+            if (bucketDuration > 0)
+            {
+                var downtimeSeconds = outages.Sum(outage => DashboardMetricsHelper.CalculateOverlapSeconds(outage, cursor, bucketEnd));
+                var uptime = Math.Clamp(1 - (downtimeSeconds / bucketDuration), 0, 1);
+                uptimePct = Math.Round(uptime * 100, 2);
+            }
+
+            buckets.Add(new UptimeBucketDto
+            {
+                Start = cursor,
+                End = bucketEnd,
+                UptimePercentage = uptimePct
+            });
+
+            cursor = bucketEnd;
+        }
+
+        return buckets;
+    }
+
+    public async Task<List<DashboardIncidentDto>> GetIncidentsAsync(Guid targetId, DateTime from, DateTime to, int skip = 0, int max = 100)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+        var (rangeStart, rangeEnd) = NormalizeRange(from, to);
+        var sanitizedSkip = skip < 0 ? 0 : skip;
+        var sanitizedMax = max <= 0 ? DefaultIncidentPageSize : Math.Min(max, 500);
+
+        var outageQuery = await _outageRepository.GetQueryableAsync();
+        outageQuery = outageQuery
+            .Where(o => o.TargetId == targetId)
+            .Where(o => o.StartedAt <= rangeEnd && (o.EndedAt == null || o.EndedAt >= rangeStart))
+            .OrderByDescending(o => o.StartedAt);
+
+        var outages = await AsyncExecuter.ToListAsync(
+            outageQuery
+                .Skip(sanitizedSkip)
+                .Take(sanitizedMax));
+
+        return outages
+            .Select(o => new DashboardIncidentDto
+            {
+                Id = o.Id,
+                TargetId = o.TargetId,
+                StartedAt = o.StartedAt,
+                EndedAt = o.EndedAt,
+                FailureCount = o.FailureCount,
+                TotalDurationSec = o.TotalDurationSec
+            })
+            .ToList();
+    }
+
+    public async Task<MttrMtbfDto> GetReliabilityAsync(DateTime from, DateTime to, ServiceType? filterType = null)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+        var (rangeStart, rangeEnd) = NormalizeRange(from, to);
+
+        var targetQuery = await _targetRepository.GetQueryableAsync();
+        if (filterType.HasValue)
+        {
+            targetQuery = targetQuery.Where(t => t.Type == filterType.Value);
+        }
+
+        var targetSnapshots = await AsyncExecuter.ToListAsync(
+            targetQuery.Select(t => new
+            {
+                t.Id,
+                t.Type
+            }));
+
+        var targetIds = targetSnapshots.Select(t => t.Id).ToList();
+        if (!targetIds.Any())
+        {
+            return new MttrMtbfDto();
+        }
+
+        var outages = await LoadOutagesAsync(targetIds, rangeStart, rangeEnd);
+        var closedOutages = outages
+            .Where(o => o.EndedAt.HasValue)
+            .OrderBy(o => o.StartedAt)
+            .ToList();
+
+        var result = new MttrMtbfDto();
+        if (!closedOutages.Any())
+        {
+            return result;
+        }
+
+        var mttr = DashboardMetricsHelper.CalculateMttrSeconds(closedOutages, rangeStart, rangeEnd);
+        if (mttr.HasValue)
+        {
+            result.MeanTimeToRecoverSeconds = mttr.Value;
+        }
+
+        var mtbfDurations = closedOutages
+            .GroupBy(o => o.TargetId)
+            .SelectMany(group => DashboardMetricsHelper.CalculateMtbfSeconds(group))
+            .ToList();
+
+        if (mtbfDurations.Any())
+        {
+            result.MeanTimeBetweenFailuresSeconds = Math.Round(mtbfDurations.Average(), 2);
+        }
+
+        foreach (var serviceGrouping in targetSnapshots.GroupBy(t => t.Type))
+        {
+            var serviceTargetIds = serviceGrouping.Select(t => t.Id).ToHashSet();
+            var serviceOutages = closedOutages.Where(o => serviceTargetIds.Contains(o.TargetId)).ToList();
+            if (!serviceOutages.Any())
+            {
+                continue;
+            }
+
+            var serviceMttr = DashboardMetricsHelper.CalculateMttrSeconds(serviceOutages, rangeStart, rangeEnd);
+            var serviceMtbfDurations = DashboardMetricsHelper.CalculateMtbfSeconds(serviceOutages);
+
+            result.Breakdown.Add(new MttrMtbfBreakdownDto
+            {
+                ServiceType = serviceGrouping.Key,
+                MeanTimeToRecoverSeconds = serviceMttr,
+                MeanTimeBetweenFailuresSeconds = serviceMtbfDurations.Any()
+                    ? Math.Round(serviceMtbfDurations.Average(), 2)
+                    : null
+            });
+        }
+
+        return result;
+    }
+
+    private (DateTime start, DateTime end) NormalizeRange(DateTime from, DateTime to)
+    {
+        if (from == default)
+        {
+            from = Clock.Now.AddDays(-_options.Dashboard.DefaultRangeDays);
+        }
+
+        if (to == default)
+        {
+            to = Clock.Now;
+        }
+
+        if (to <= from)
+        {
+            throw new BusinessException("InvalidRange")
+                .WithData("from", from.ToString("O", CultureInfo.InvariantCulture))
+                .WithData("to", to.ToString("O", CultureInfo.InvariantCulture));
+        }
+
+        var maxRange = TimeSpan.FromDays(Math.Max(1, _options.Dashboard.MaxRangeDays));
+        if (to - from > maxRange)
+        {
+            to = from.Add(maxRange);
+        }
+
+        return (from, to);
+    }
+
+    private static TimeSpan ResolveBucketLength(string bucket)
+    {
+        return bucket?.Equals("hour", StringComparison.OrdinalIgnoreCase) == true
+            ? TimeSpan.FromHours(1)
+            : TimeSpan.FromDays(1);
+    }
+
+    private async Task<List<OutageWindow>> LoadOutagesAsync(List<Guid> targetIds, DateTime rangeStart, DateTime rangeEnd)
+    {
+        if (targetIds.Count == 0)
+        {
+            return new List<OutageWindow>();
+        }
+
+        var outageQuery = await _outageRepository.GetQueryableAsync();
+        outageQuery = outageQuery
+            .Where(o => targetIds.Contains(o.TargetId))
+            .Where(o => o.StartedAt <= rangeEnd && (o.EndedAt == null || o.EndedAt >= rangeStart));
+
+        return await AsyncExecuter.ToListAsync(outageQuery);
+    }
+}

--- a/src/Monitoring.Application/Dashboard/DashboardMetricsHelper.cs
+++ b/src/Monitoring.Application/Dashboard/DashboardMetricsHelper.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Monitoring.Targets;
+
+namespace Monitoring.Dashboard;
+
+internal static class DashboardMetricsHelper
+{
+    public static double CalculateOverlapSeconds(OutageWindow outage, DateTime start, DateTime end)
+    {
+        var overlapStart = outage.StartedAt > start ? outage.StartedAt : start;
+        var outageEnd = outage.EndedAt ?? end;
+        var overlapEnd = outageEnd < end ? outageEnd : end;
+
+        if (overlapEnd <= overlapStart)
+        {
+            return 0;
+        }
+
+        return (overlapEnd - overlapStart).TotalSeconds;
+    }
+
+    public static double? CalculateMttrSeconds(IEnumerable<OutageWindow> outages, DateTime rangeStart, DateTime rangeEnd)
+    {
+        var durations = outages
+            .Where(outage => outage.EndedAt.HasValue || outage.TotalDurationSec.HasValue)
+            .Select(outage => outage.TotalDurationSec ?? (int)Math.Max(0, (Math.Min(rangeEnd.Ticks, (outage.EndedAt ?? rangeEnd).Ticks) - Math.Max(rangeStart.Ticks, outage.StartedAt.Ticks)) / TimeSpan.TicksPerSecond))
+            .Where(duration => duration > 0)
+            .Select(duration => (double)duration)
+            .ToList();
+
+        if (!durations.Any())
+        {
+            return null;
+        }
+
+        return Math.Round(durations.Average(), 2);
+    }
+
+    public static List<double> CalculateMtbfSeconds(IEnumerable<OutageWindow> outages)
+    {
+        var gaps = new List<double>();
+        OutageWindow? previous = null;
+        foreach (var outage in outages.OrderBy(o => o.StartedAt))
+        {
+            if (previous != null && previous.EndedAt.HasValue)
+            {
+                var gap = (outage.StartedAt - previous.EndedAt.Value).TotalSeconds;
+                if (gap > 0)
+                {
+                    gaps.Add(gap);
+                }
+            }
+
+            previous = outage;
+        }
+
+        return gaps;
+    }
+}

--- a/src/Monitoring.Application/Monitoring.Application.csproj
+++ b/src/Monitoring.Application/Monitoring.Application.csproj
@@ -17,7 +17,8 @@
     <PackageReference Include="Volo.Abp.AutoMapper" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Ddd.Application" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Authorization" Version="8.3.1" />
-    <PackageReference Include="Volo.Abp.BackgroundWorkers" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.Uow" Version="8.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Monitoring.Application/Monitoring.Application.csproj
+++ b/src/Monitoring.Application/Monitoring.Application.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\\..\\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\Monitoring.Domain\\Monitoring.Domain.csproj" />
+    <ProjectReference Include="..\\Monitoring.Application.Contracts\\Monitoring.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.AutoMapper" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.Ddd.Application" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.Authorization" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.BackgroundWorkers" Version="8.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Monitoring.Application/Monitoring.Application.csproj
+++ b/src/Monitoring.Application/Monitoring.Application.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Volo.Abp.Ddd.Application" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Authorization" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Uow" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.Emailing" Version="8.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 

--- a/src/Monitoring.Application/Monitoring.Application.csproj
+++ b/src/Monitoring.Application/Monitoring.Application.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Volo.Abp.Ddd.Application" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Authorization" Version="8.3.1" />
     <PackageReference Include="Volo.Abp.Uow" Version="8.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Monitoring.Application/MonitoringAppService.cs
+++ b/src/Monitoring.Application/MonitoringAppService.cs
@@ -1,0 +1,13 @@
+using Monitoring.Localization;
+using Volo.Abp.Application.Services;
+
+namespace Monitoring;
+
+public abstract class MonitoringAppService : ApplicationService
+{
+    protected MonitoringAppService()
+    {
+        LocalizationResource = typeof(MonitoringResource);
+        ObjectMapperContext = typeof(MonitoringApplicationModule);
+    }
+}

--- a/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
+++ b/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
@@ -8,5 +8,7 @@ public class MonitoringApplicationAutoMapperProfile : Profile
     public MonitoringApplicationAutoMapperProfile()
     {
         CreateMap<MonitoringTarget, MonitoringTargetDto>();
+        CreateMap<ServiceStatusHistory, ServiceStatusHistoryDto>();
+        CreateMap<OutageWindow, OutageWindowDto>();
     }
 }

--- a/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
+++ b/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
@@ -1,0 +1,12 @@
+using AutoMapper;
+using Monitoring.Targets;
+
+namespace Monitoring;
+
+public class MonitoringApplicationAutoMapperProfile : Profile
+{
+    public MonitoringApplicationAutoMapperProfile()
+    {
+        CreateMap<MonitoringTarget, MonitoringTargetDto>();
+    }
+}

--- a/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
+++ b/src/Monitoring.Application/MonitoringApplicationAutoMapperProfile.cs
@@ -10,5 +10,7 @@ public class MonitoringApplicationAutoMapperProfile : Profile
         CreateMap<MonitoringTarget, MonitoringTargetDto>();
         CreateMap<ServiceStatusHistory, ServiceStatusHistoryDto>();
         CreateMap<OutageWindow, OutageWindowDto>();
+        CreateMap<AlertPolicy, AlertPolicyDto>();
+        CreateMap<MaintenanceWindow, MaintenanceWindowDto>();
     }
 }

--- a/src/Monitoring.Application/MonitoringApplicationModule.cs
+++ b/src/Monitoring.Application/MonitoringApplicationModule.cs
@@ -5,7 +5,7 @@ using Monitoring.Workers;
 using Volo.Abp;
 using Volo.Abp.AutoMapper;
 using Volo.Abp.Authorization;
-using Volo.Abp.BackgroundWorkers;
+using Volo.Abp.Application;
 using Volo.Abp.Modularity;
 
 namespace Monitoring;
@@ -15,7 +15,7 @@ namespace Monitoring;
     typeof(MonitoringApplicationContractsModule),
     typeof(AbpAutoMapperModule),
     typeof(AbpAuthorizationModule),
-    typeof(AbpBackgroundWorkersModule)
+    typeof(AbpDddApplicationModule)
     )]
 public class MonitoringApplicationModule : AbpModule
 {
@@ -28,7 +28,7 @@ public class MonitoringApplicationModule : AbpModule
         context.Services.AddTransient<TcpCheckProvider>();
         context.Services.AddTransient<RedisCheckProvider>();
         context.Services.AddTransient<IHealthCheckProviderResolver, HealthCheckProviderResolver>();
-        context.Services.AddHostedService<AbpBackgroundWorkerAdapter<MonitoringWorker>>();
+        context.Services.AddHostedService<MonitoringWorker>();
 
         Configure<AbpAutoMapperOptions>(options =>
         {

--- a/src/Monitoring.Application/MonitoringApplicationModule.cs
+++ b/src/Monitoring.Application/MonitoringApplicationModule.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Monitoring.Alerts;
 using Monitoring.HealthChecks;
 using Monitoring.Options;
 using Monitoring.Workers;
@@ -30,6 +31,7 @@ public class MonitoringApplicationModule : AbpModule
         context.Services.AddTransient<TcpCheckProvider>();
         context.Services.AddTransient<RedisCheckProvider>();
         context.Services.AddTransient<IHealthCheckProviderResolver, HealthCheckProviderResolver>();
+        context.Services.AddTransient<INotificationChannelResolver, NotificationChannelResolver>();
         context.Services.AddHostedService<MonitoringWorker>();
 
         var configuration = context.Services.GetConfiguration();

--- a/src/Monitoring.Application/MonitoringApplicationModule.cs
+++ b/src/Monitoring.Application/MonitoringApplicationModule.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Monitoring.HealthChecks;
+using Monitoring.Options;
 using Monitoring.Workers;
 using Volo.Abp;
 using Volo.Abp.AutoMapper;
@@ -29,6 +31,9 @@ public class MonitoringApplicationModule : AbpModule
         context.Services.AddTransient<RedisCheckProvider>();
         context.Services.AddTransient<IHealthCheckProviderResolver, HealthCheckProviderResolver>();
         context.Services.AddHostedService<MonitoringWorker>();
+
+        var configuration = context.Services.GetConfiguration();
+        Configure<MonitoringOptions>(configuration.GetSection("Monitoring"));
 
         Configure<AbpAutoMapperOptions>(options =>
         {

--- a/src/Monitoring.Application/MonitoringApplicationModule.cs
+++ b/src/Monitoring.Application/MonitoringApplicationModule.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Monitoring.HealthChecks;
+using Monitoring.Workers;
+using Volo.Abp;
+using Volo.Abp.AutoMapper;
+using Volo.Abp.Authorization;
+using Volo.Abp.BackgroundWorkers;
+using Volo.Abp.Modularity;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(MonitoringDomainModule),
+    typeof(MonitoringApplicationContractsModule),
+    typeof(AbpAutoMapperModule),
+    typeof(AbpAuthorizationModule),
+    typeof(AbpBackgroundWorkersModule)
+    )]
+public class MonitoringApplicationModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddHttpClient();
+        context.Services.TryAddSingleton<ISecretResolver, EnvironmentSecretResolver>();
+        context.Services.AddTransient<WebsiteCheckProvider>();
+        context.Services.AddTransient<ApiCheckProvider>();
+        context.Services.AddTransient<TcpCheckProvider>();
+        context.Services.AddTransient<RedisCheckProvider>();
+        context.Services.AddTransient<IHealthCheckProviderResolver, HealthCheckProviderResolver>();
+        context.Services.AddHostedService<AbpBackgroundWorkerAdapter<MonitoringWorker>>();
+
+        Configure<AbpAutoMapperOptions>(options =>
+        {
+            options.AddMaps<MonitoringApplicationModule>();
+        });
+    }
+
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+    }
+}

--- a/src/Monitoring.Application/Options/MonitoringOptions.cs
+++ b/src/Monitoring.Application/Options/MonitoringOptions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Monitoring.Options;
+
+public class MonitoringOptions
+{
+    public AlertDefaultsOptions AlertDefaults { get; set; } = new();
+
+    public class AlertDefaultsOptions
+    {
+        public bool Enabled { get; set; } = true;
+
+        public int NotifyAfterFailures { get; set; } = 1;
+
+        public int RepeatMinutes { get; set; } = 60;
+
+        public int RecoverQuietMinutes { get; set; } = 10;
+
+        public bool SuppressDuringMaintenance { get; set; } = true;
+
+        public Dictionary<string, string[]>? DefaultChannels { get; set; }
+            = new();
+    }
+}

--- a/src/Monitoring.Application/Options/MonitoringOptions.cs
+++ b/src/Monitoring.Application/Options/MonitoringOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Monitoring.Options;
@@ -5,6 +6,7 @@ namespace Monitoring.Options;
 public class MonitoringOptions
 {
     public AlertDefaultsOptions AlertDefaults { get; set; } = new();
+    public NotificationChannelOptions Notifications { get; set; } = new();
 
     public class AlertDefaultsOptions
     {
@@ -19,6 +21,35 @@ public class MonitoringOptions
         public bool SuppressDuringMaintenance { get; set; } = true;
 
         public Dictionary<string, string[]>? DefaultChannels { get; set; }
+            = new();
+    }
+
+    public class NotificationChannelOptions
+    {
+        public EmailChannelOptions Email { get; set; } = new();
+        public TelegramChannelOptions Telegram { get; set; } = new();
+        public WebhookChannelOptions Webhook { get; set; } = new();
+    }
+
+    public class EmailChannelOptions
+    {
+        public string? FromAddress { get; set; }
+            = null;
+
+        public string SubjectPrefix { get; set; } = "[Monitoring]";
+    }
+
+    public class TelegramChannelOptions
+    {
+        public string? BotToken { get; set; }
+            = null;
+
+        public string[] ChatIds { get; set; } = Array.Empty<string>();
+    }
+
+    public class WebhookChannelOptions
+    {
+        public Dictionary<string, string>? DefaultHeaders { get; set; }
             = new();
     }
 }

--- a/src/Monitoring.Application/Options/MonitoringOptions.cs
+++ b/src/Monitoring.Application/Options/MonitoringOptions.cs
@@ -7,6 +7,7 @@ public class MonitoringOptions
 {
     public AlertDefaultsOptions AlertDefaults { get; set; } = new();
     public NotificationChannelOptions Notifications { get; set; } = new();
+    public DashboardOptions Dashboard { get; set; } = new();
 
     public class AlertDefaultsOptions
     {
@@ -51,5 +52,12 @@ public class MonitoringOptions
     {
         public Dictionary<string, string>? DefaultHeaders { get; set; }
             = new();
+    }
+
+    public class DashboardOptions
+    {
+        public int DefaultRangeDays { get; set; } = 7;
+
+        public int MaxRangeDays { get; set; } = 180;
     }
 }

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -6,12 +6,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Monitoring.HealthChecks;
+using Monitoring.Options;
 using Monitoring.Permissions;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Authorization;
+using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
 
@@ -27,24 +30,40 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         PropertyNameCaseInsensitive = true
     };
 
+    private static readonly JsonSerializerOptions AlertChannelsSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
     private readonly IRepository<MonitoringTarget, Guid> _repository;
     private readonly IHealthCheckProviderResolver _providerResolver;
     private readonly IRepository<ServiceStatusHistory, Guid> _historyRepository;
     private readonly IRepository<OutageWindow, Guid> _outageRepository;
+    private readonly IRepository<AlertPolicy, Guid> _alertPolicyRepository;
+    private readonly IRepository<MaintenanceWindow, Guid> _maintenanceRepository;
     private readonly IGuidGenerator _guidGenerator;
+    private readonly MonitoringOptions _options;
 
     public MonitoringTargetAppService(
         IRepository<MonitoringTarget, Guid> repository,
         IHealthCheckProviderResolver providerResolver,
         IRepository<ServiceStatusHistory, Guid> historyRepository,
         IRepository<OutageWindow, Guid> outageRepository,
-        IGuidGenerator guidGenerator)
+        IRepository<AlertPolicy, Guid> alertPolicyRepository,
+        IRepository<MaintenanceWindow, Guid> maintenanceRepository,
+        IGuidGenerator guidGenerator,
+        IOptions<MonitoringOptions> options)
     {
         _repository = repository;
         _providerResolver = providerResolver;
         _historyRepository = historyRepository;
         _outageRepository = outageRepository;
+        _alertPolicyRepository = alertPolicyRepository;
+        _maintenanceRepository = maintenanceRepository;
         _guidGenerator = guidGenerator;
+        _options = options.Value;
     }
 
     public async Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(
@@ -285,6 +304,143 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         return ObjectMapper.Map<List<ServiceStatusHistory>, List<ServiceStatusHistoryDto>>(history);
     }
 
+    public async Task<AlertPolicyDto> GetAlertPolicyAsync(Guid targetId)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        await EnsureTargetExistsAsync(targetId);
+
+        var policy = await _alertPolicyRepository.FirstOrDefaultAsync(x => x.TargetId == targetId);
+        if (policy == null)
+        {
+            var defaults = _options.AlertDefaults;
+            return new AlertPolicyDto
+            {
+                TargetId = targetId,
+                Enabled = defaults.Enabled,
+                NotifyAfterFailures = defaults.NotifyAfterFailures,
+                RepeatMinutes = defaults.RepeatMinutes,
+                RecoverQuietMinutes = defaults.RecoverQuietMinutes,
+                ChannelsJson = SerializeDefaultChannels(defaults.DefaultChannels),
+                SuppressDuringMaintenance = defaults.SuppressDuringMaintenance,
+                IsInherited = true
+            };
+        }
+
+        var dto = ObjectMapper.Map<AlertPolicy, AlertPolicyDto>(policy);
+        dto.IsInherited = false;
+        return dto;
+    }
+
+    public async Task<AlertPolicyDto> UpsertAlertPolicyAsync(Guid targetId, AlertPolicyDto input)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Edit);
+
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        await EnsureTargetExistsAsync(targetId);
+
+        if (input.TargetId != Guid.Empty && input.TargetId != targetId)
+        {
+            throw new UserFriendlyException("TargetId mismatch.");
+        }
+
+        input.TargetId = targetId;
+
+        ValidateAlertPolicyInput(input);
+
+        var normalizedChannels = NormalizeChannelsJson(input.ChannelsJson);
+
+        var existing = await _alertPolicyRepository.FirstOrDefaultAsync(x => x.TargetId == targetId);
+        if (existing == null)
+        {
+            existing = new AlertPolicy(
+                _guidGenerator.Create(),
+                targetId,
+                input.Enabled,
+                input.NotifyAfterFailures,
+                input.RepeatMinutes,
+                input.RecoverQuietMinutes,
+                normalizedChannels,
+                input.SuppressDuringMaintenance);
+
+            await _alertPolicyRepository.InsertAsync(existing, autoSave: true);
+        }
+        else
+        {
+            existing.Update(
+                input.Enabled,
+                input.NotifyAfterFailures,
+                input.RepeatMinutes,
+                input.RecoverQuietMinutes,
+                normalizedChannels,
+                input.SuppressDuringMaintenance);
+
+            await _alertPolicyRepository.UpdateAsync(existing, autoSave: true);
+        }
+
+        var dto = ObjectMapper.Map<AlertPolicy, AlertPolicyDto>(existing);
+        dto.TargetId = targetId;
+        dto.IsInherited = false;
+        return dto;
+    }
+
+    public async Task<List<MaintenanceWindowDto>> GetMaintenanceAsync(Guid? targetId = null)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        var queryable = await _maintenanceRepository.GetQueryableAsync();
+
+        if (targetId.HasValue)
+        {
+            var id = targetId.Value;
+            queryable = queryable.Where(x => x.TargetId == null || x.TargetId == id);
+        }
+
+        var windows = await AsyncExecuter.ToListAsync(
+            queryable
+                .OrderBy(x => x.StartUtc));
+
+        return ObjectMapper.Map<List<MaintenanceWindow>, List<MaintenanceWindowDto>>(windows);
+    }
+
+    public async Task<MaintenanceWindowDto> CreateMaintenanceAsync(CreateUpdateMaintenanceWindowDto input)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Edit);
+
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        ValidateMaintenanceWindow(input);
+
+        if (input.TargetId.HasValue)
+        {
+            await EnsureTargetExistsAsync(input.TargetId.Value);
+        }
+
+        var entity = new MaintenanceWindow(
+            _guidGenerator.Create(),
+            input.TargetId,
+            input.StartUtc,
+            input.EndUtc,
+            input.Reason);
+
+        var created = await _maintenanceRepository.InsertAsync(entity, autoSave: true);
+        return ObjectMapper.Map<MaintenanceWindow, MaintenanceWindowDto>(created);
+    }
+
+    public async Task DeleteMaintenanceAsync(Guid id)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Edit);
+
+        await _maintenanceRepository.DeleteAsync(id);
+    }
+
     private IQueryable<MonitoringTarget> ApplySorting(IQueryable<MonitoringTarget> query, string? sorting)
     {
         if (sorting.IsNullOrWhiteSpace())
@@ -344,6 +500,110 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         }
 
         ValidateEndpointAndSettings(input);
+    }
+
+    private void ValidateAlertPolicyInput(AlertPolicyDto input)
+    {
+        if (input.NotifyAfterFailures < 1)
+        {
+            throw new UserFriendlyException("NotifyAfterFailures must be at least 1.");
+        }
+
+        if (input.RepeatMinutes < 1)
+        {
+            throw new UserFriendlyException("RepeatMinutes must be at least 1.");
+        }
+
+        if (input.RecoverQuietMinutes < 0)
+        {
+            throw new UserFriendlyException("RecoverQuietMinutes cannot be negative.");
+        }
+
+        if (!input.ChannelsJson.IsNullOrWhiteSpace())
+        {
+            if (input.ChannelsJson!.Length > AlertPolicyConsts.ChannelsJsonMaxLength)
+            {
+                throw new UserFriendlyException($"ChannelsJson cannot exceed {AlertPolicyConsts.ChannelsJsonMaxLength} characters.");
+            }
+
+            try
+            {
+                JsonDocument.Parse(input.ChannelsJson);
+            }
+            catch (JsonException)
+            {
+                throw new UserFriendlyException("ChannelsJson must be valid JSON.");
+            }
+        }
+    }
+
+    private void ValidateMaintenanceWindow(CreateUpdateMaintenanceWindowDto input)
+    {
+        if (input.StartUtc == default)
+        {
+            throw new UserFriendlyException("StartUtc is required.");
+        }
+
+        if (input.EndUtc == default)
+        {
+            throw new UserFriendlyException("EndUtc is required.");
+        }
+
+        if (input.EndUtc <= input.StartUtc)
+        {
+            throw new UserFriendlyException("EndUtc must be greater than StartUtc.");
+        }
+
+        if (!input.Reason.IsNullOrWhiteSpace() && input.Reason!.Length > MaintenanceWindowConsts.ReasonMaxLength)
+        {
+            throw new UserFriendlyException($"Reason cannot exceed {MaintenanceWindowConsts.ReasonMaxLength} characters.");
+        }
+    }
+
+    private string? NormalizeChannelsJson(string? channelsJson)
+    {
+        if (channelsJson.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(channelsJson);
+            var normalized = JsonSerializer.Serialize(document.RootElement, AlertChannelsSerializerOptions);
+
+            if (normalized.Length > AlertPolicyConsts.ChannelsJsonMaxLength)
+            {
+                throw new UserFriendlyException($"ChannelsJson cannot exceed {AlertPolicyConsts.ChannelsJsonMaxLength} characters.");
+            }
+
+            return normalized;
+        }
+        catch (JsonException)
+        {
+            throw new UserFriendlyException("ChannelsJson must be valid JSON.");
+        }
+    }
+
+    private string? SerializeDefaultChannels(Dictionary<string, string[]>? channels)
+    {
+        if (channels == null || channels.Count == 0)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(channels, AlertChannelsSerializerOptions);
+    }
+
+    private async Task<MonitoringTarget> EnsureTargetExistsAsync(Guid targetId)
+    {
+        var target = await _repository.FindAsync(targetId);
+        if (target == null)
+        {
+            throw new EntityNotFoundException(typeof(MonitoringTarget), targetId);
+        }
+
+        return target;
     }
 
     private void ValidateEndpointAndSettings(CreateUpdateMonitoringTargetDto input)

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
 using Monitoring.HealthChecks;
 using Monitoring.Permissions;
 using Volo.Abp.Application.Dtos;
@@ -85,8 +86,7 @@ public class MonitoringTargetAppService :
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var cancellationToken = CancellationTokenProvider.Token;
-        var entity = await Repository.GetAsync(id, cancellationToken: cancellationToken);
+        var entity = await Repository.GetAsync(id);
 
         var now = Clock.Now;
         entity.SetLastCheckedAt(now);
@@ -95,19 +95,20 @@ public class MonitoringTargetAppService :
         entity.SetLastStatusChangeAt(now);
         entity.SetConsecutiveFailures(0);
 
-        await Repository.UpdateAsync(entity, autoSave: true, cancellationToken: cancellationToken);
+        await Repository.UpdateAsync(entity, autoSave: true);
     }
 
     public async Task<HealthCheckResultDto> CheckNowAsync(Guid id)
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var cancellationToken = CancellationTokenProvider.Token;
-        var target = await Repository.GetAsync(id, cancellationToken: cancellationToken);
+        var target = await Repository.GetAsync(id);
 
-        var (result, timestamp) = await ExecuteCheckAsync(target, ManualTriggerSource, cancellationToken);
+        var execution = await ExecuteCheckAsync(target, ManualTriggerSource);
+        var result = execution.Result;
+        var timestamp = execution.Timestamp;
 
-        await Repository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
+        await Repository.UpdateAsync(target, autoSave: true);
 
         return CreateResultDto(target, result, timestamp);
     }
@@ -116,19 +117,16 @@ public class MonitoringTargetAppService :
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var cancellationToken = CancellationTokenProvider.Token;
-        var targets = await Repository.GetListAsync(target => target.IsActive, cancellationToken: cancellationToken);
+        var targets = await Repository.GetListAsync(target => target.IsActive);
 
         var results = new List<HealthCheckResultDto>(targets.Count);
 
         foreach (var target in targets)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            var execution = await ExecuteCheckAsync(target, BulkTriggerSource);
+            await Repository.UpdateAsync(target, autoSave: true);
 
-            var (result, timestamp) = await ExecuteCheckAsync(target, BulkTriggerSource, cancellationToken);
-            await Repository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
-
-            results.Add(CreateResultDto(target, result, timestamp));
+            results.Add(CreateResultDto(target, execution.Result, execution.Timestamp));
         }
 
         return results;
@@ -137,7 +135,7 @@ public class MonitoringTargetAppService :
     private async Task<(HealthCheckResult Result, DateTime Timestamp)> ExecuteCheckAsync(
         MonitoringTarget target,
         string triggerSource,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         HealthCheckResult result;
         try

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -100,6 +100,25 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
                 .Take(maxResultCount));
 
         var dtos = ObjectMapper.Map<List<MonitoringTarget>, List<MonitoringTargetDto>>(items);
+
+        if (dtos.Count > 0)
+        {
+            var now = Clock.Now;
+            var targetIds = dtos.Select(x => x.Id).ToList();
+            var activeWindows = await AsyncExecuter.ToListAsync(
+                _maintenanceRepository.Where(
+                    window => window.StartUtc <= now && window.EndUtc >= now &&
+                              (window.TargetId == null || targetIds.Contains(window.TargetId.Value))));
+
+            var hasGlobal = activeWindows.Any(window => window.TargetId == null);
+            var targeted = new HashSet<Guid>(activeWindows.Where(window => window.TargetId.HasValue).Select(window => window.TargetId!.Value));
+
+            foreach (var dto in dtos)
+            {
+                dto.HasActiveMaintenance = hasGlobal || targeted.Contains(dto.Id);
+            }
+        }
+
         return new PagedResultDto<MonitoringTargetDto>(totalCount, dtos);
     }
 
@@ -107,7 +126,14 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
         var entity = await _repository.GetAsync(id);
-        return ObjectMapper.Map<MonitoringTarget, MonitoringTargetDto>(entity);
+        var dto = ObjectMapper.Map<MonitoringTarget, MonitoringTargetDto>(entity);
+
+        var now = Clock.Now;
+        dto.HasActiveMaintenance = await _maintenanceRepository.AnyAsync(
+            window => window.StartUtc <= now && window.EndUtc >= now &&
+                      (window.TargetId == null || window.TargetId == id));
+
+        return dto;
     }
 
     public async Task<MonitoringTargetDto> CreateAsync(CreateUpdateMonitoringTargetDto input)
@@ -269,7 +295,27 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
             queryable
                 .OrderBy(target => target.Name));
 
-        return ObjectMapper.Map<List<MonitoringTarget>, List<MonitoringTargetDto>>(targets);
+        var dtos = ObjectMapper.Map<List<MonitoringTarget>, List<MonitoringTargetDto>>(targets);
+
+        if (dtos.Count > 0)
+        {
+            var now = Clock.Now;
+            var ids = dtos.Select(x => x.Id).ToList();
+            var activeWindows = await AsyncExecuter.ToListAsync(
+                _maintenanceRepository.Where(
+                    window => window.StartUtc <= now && window.EndUtc >= now &&
+                              (window.TargetId == null || ids.Contains(window.TargetId.Value))));
+
+            var hasGlobal = activeWindows.Any(window => window.TargetId == null);
+            var targeted = new HashSet<Guid>(activeWindows.Where(window => window.TargetId.HasValue).Select(window => window.TargetId!.Value));
+
+            foreach (var dto in dtos)
+            {
+                dto.HasActiveMaintenance = hasGlobal || targeted.Contains(dto.Id);
+            }
+        }
+
+        return dtos;
     }
 
     public async Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10)
@@ -402,7 +448,7 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
 
         var windows = await AsyncExecuter.ToListAsync(
             queryable
-                .OrderBy(x => x.StartUtc));
+                .OrderByDescending(x => x.StartUtc));
 
         return ObjectMapper.Map<List<MaintenanceWindow>, List<MaintenanceWindowDto>>(windows);
     }
@@ -744,7 +790,7 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         }
 
         var timestamp = Clock.Now;
-        await MonitoringTargetCheckProcessor.ApplyResultAsync(
+        _ = await MonitoringTargetCheckProcessor.ApplyResultAsync(
             target,
             result,
             timestamp,

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -168,6 +168,24 @@ public class MonitoringTargetAppService :
         return targets.Count;
     }
 
+    public async Task<List<MonitoringTargetDto>> GetOverviewAsync(ServiceType? type = null)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        var queryable = await Repository.GetQueryableAsync();
+
+        if (type.HasValue)
+        {
+            queryable = queryable.Where(target => target.Type == type.Value);
+        }
+
+        var targets = await AsyncExecuter.ToListAsync(
+            queryable
+                .OrderBy(target => target.Name));
+
+        return ObjectMapper.Map<List<MonitoringTarget>, List<MonitoringTargetDto>>(targets);
+    }
+
     public async Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10)
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Monitoring.HealthChecks;
 using Monitoring.Permissions;

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -105,10 +105,11 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         {
             var now = Clock.Now;
             var targetIds = dtos.Select(x => x.Id).ToList();
+            var maintenanceQueryable = await _maintenanceRepository.GetQueryableAsync();
             var activeWindows = await AsyncExecuter.ToListAsync(
-                _maintenanceRepository.Where(
-                    window => window.StartUtc <= now && window.EndUtc >= now &&
-                              (window.TargetId == null || targetIds.Contains(window.TargetId.Value))));
+                maintenanceQueryable
+                    .Where(window => window.StartUtc <= now && window.EndUtc >= now)
+                    .Where(window => window.TargetId == null || targetIds.Contains(window.TargetId.Value)));
 
             var hasGlobal = activeWindows.Any(window => window.TargetId == null);
             var targeted = new HashSet<Guid>(activeWindows.Where(window => window.TargetId.HasValue).Select(window => window.TargetId!.Value));
@@ -301,10 +302,11 @@ public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetA
         {
             var now = Clock.Now;
             var ids = dtos.Select(x => x.Id).ToList();
+            var maintenanceQueryable = await _maintenanceRepository.GetQueryableAsync();
             var activeWindows = await AsyncExecuter.ToListAsync(
-                _maintenanceRepository.Where(
-                    window => window.StartUtc <= now && window.EndUtc >= now &&
-                              (window.TargetId == null || ids.Contains(window.TargetId.Value))));
+                maintenanceQueryable
+                    .Where(window => window.StartUtc <= now && window.EndUtc >= now)
+                    .Where(window => window.TargetId == null || ids.Contains(window.TargetId.Value)));
 
             var hasGlobal = activeWindows.Any(window => window.TargetId == null);
             var targeted = new HashSet<Guid>(activeWindows.Where(window => window.TargetId.HasValue).Select(window => window.TargetId!.Value));

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -8,8 +9,9 @@ using Monitoring.HealthChecks;
 using Monitoring.Permissions;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
-using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Authorization;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Guids;
 
 namespace Monitoring.Targets;
 
@@ -21,13 +23,22 @@ public class MonitoringTargetAppService :
     private const string BulkTriggerSource = "api";
 
     private readonly IHealthCheckProviderResolver _providerResolver;
+    private readonly IRepository<ServiceStatusHistory, Guid> _historyRepository;
+    private readonly IRepository<OutageWindow, Guid> _outageRepository;
+    private readonly IGuidGenerator _guidGenerator;
 
     public MonitoringTargetAppService(
         IRepository<MonitoringTarget, Guid> repository,
-        IHealthCheckProviderResolver providerResolver)
+        IHealthCheckProviderResolver providerResolver,
+        IRepository<ServiceStatusHistory, Guid> historyRepository,
+        IRepository<OutageWindow, Guid> outageRepository,
+        IGuidGenerator guidGenerator)
         : base(repository)
     {
         _providerResolver = providerResolver;
+        _historyRepository = historyRepository;
+        _outageRepository = outageRepository;
+        _guidGenerator = guidGenerator;
         GetPolicyName = MonitoringPermissions.Services.View;
         GetListPolicyName = MonitoringPermissions.Services.View;
         CreatePolicyName = MonitoringPermissions.Services.Create;
@@ -90,7 +101,7 @@ public class MonitoringTargetAppService :
 
         var now = Clock.Now;
         entity.SetLastCheckedAt(now);
-        entity.SetNextDueAt(now.AddSeconds(entity.CheckIntervalSeconds));
+        entity.SetNextDueAt(now);
         entity.SetCurrentStatus(ServiceStatus.Checking);
         entity.SetLastStatusChangeAt(now);
         entity.SetConsecutiveFailures(0);
@@ -132,6 +143,63 @@ public class MonitoringTargetAppService :
         return results;
     }
 
+    public async Task<int> CheckAllNowAsync()
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
+
+        var targets = await Repository.GetListAsync(target => target.IsActive);
+        var now = Clock.Now;
+
+        foreach (var target in targets)
+        {
+            if (target.CurrentStatus != ServiceStatus.Checking)
+            {
+                target.SetCurrentStatus(ServiceStatus.Checking);
+                target.SetLastStatusChangeAt(now);
+            }
+
+            target.SetLastCheckedAt(now);
+            target.SetNextDueAt(now);
+            target.SetConsecutiveFailures(0);
+
+            await Repository.UpdateAsync(target, autoSave: true);
+        }
+
+        return targets.Count;
+    }
+
+    public async Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid targetId, int count = 10)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        var normalizedCount = Math.Clamp(count, 1, 100);
+        var queryable = await _outageRepository.GetQueryableAsync();
+
+        var outages = await AsyncExecuter.ToListAsync(
+            queryable
+                .Where(x => x.TargetId == targetId)
+                .OrderByDescending(x => x.StartedAt)
+                .Take(normalizedCount));
+
+        return ObjectMapper.Map<List<OutageWindow>, List<OutageWindowDto>>(outages);
+    }
+
+    public async Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid targetId, int count = 20)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        var normalizedCount = Math.Clamp(count, 1, 200);
+        var queryable = await _historyRepository.GetQueryableAsync();
+
+        var history = await AsyncExecuter.ToListAsync(
+            queryable
+                .Where(x => x.TargetId == targetId)
+                .OrderByDescending(x => x.ChangedAt)
+                .Take(normalizedCount));
+
+        return ObjectMapper.Map<List<ServiceStatusHistory>, List<ServiceStatusHistoryDto>>(history);
+    }
+
     private async Task<(HealthCheckResult Result, DateTime Timestamp)> ExecuteCheckAsync(
         MonitoringTarget target,
         string triggerSource,
@@ -150,7 +218,14 @@ public class MonitoringTargetAppService :
         }
 
         var timestamp = Clock.Now;
-        MonitoringTargetCheckProcessor.ApplyResult(target, result, timestamp);
+        await MonitoringTargetCheckProcessor.ApplyResultAsync(
+            target,
+            result,
+            timestamp,
+            _historyRepository,
+            _outageRepository,
+            _guidGenerator,
+            cancellationToken);
 
         return (result, timestamp);
     }

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Monitoring.HealthChecks;
+using Monitoring.Permissions;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Application.Services;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Authorization;
+
+namespace Monitoring.Targets;
+
+public class MonitoringTargetAppService :
+    CrudAppService<MonitoringTarget, MonitoringTargetDto, Guid, PagedAndSortedResultRequestDto, CreateUpdateMonitoringTargetDto>,
+    IMonitoringTargetAppService
+{
+    private const string ManualTriggerSource = "manual";
+    private const string BulkTriggerSource = "api";
+
+    private readonly IHealthCheckProviderResolver _providerResolver;
+
+    public MonitoringTargetAppService(
+        IRepository<MonitoringTarget, Guid> repository,
+        IHealthCheckProviderResolver providerResolver)
+        : base(repository)
+    {
+        _providerResolver = providerResolver;
+        GetPolicyName = MonitoringPermissions.Services.View;
+        GetListPolicyName = MonitoringPermissions.Services.View;
+        CreatePolicyName = MonitoringPermissions.Services.Create;
+        UpdatePolicyName = MonitoringPermissions.Services.Edit;
+        DeletePolicyName = MonitoringPermissions.Services.Delete;
+    }
+
+    protected override MonitoringTarget MapToEntity(CreateUpdateMonitoringTargetDto createInput)
+    {
+        var entity = new MonitoringTarget(
+            GuidGenerator.Create(),
+            createInput.Name,
+            createInput.Type,
+            createInput.Endpoint,
+            createInput.CheckIntervalSeconds,
+            createInput.TimeoutSeconds,
+            createInput.MaxRetryAttempts,
+            createInput.RetryDelaySeconds,
+            createInput.IsActive,
+            createInput.CurrentStatus,
+            createInput.NextDueAt,
+            createInput.SettingsJson,
+            createInput.Category
+        );
+
+        entity.SetLastCheckedAt(createInput.LastCheckedAt);
+        entity.SetLastStatusChangeAt(createInput.LastStatusChangeAt);
+        entity.SetConsecutiveFailures(createInput.ConsecutiveFailures);
+        entity.SetFirstDownAt(createInput.FirstDownAt);
+        entity.SetLastUpAt(createInput.LastUpAt);
+
+        return entity;
+    }
+
+    protected override void MapToEntity(CreateUpdateMonitoringTargetDto updateInput, MonitoringTarget entity)
+    {
+        entity.SetName(updateInput.Name);
+        entity.SetType(updateInput.Type);
+        entity.SetEndpoint(updateInput.Endpoint);
+        entity.UpdateCheckIntervalSeconds(updateInput.CheckIntervalSeconds);
+        entity.UpdateTimeoutSeconds(updateInput.TimeoutSeconds);
+        entity.UpdateRetrySettings(updateInput.MaxRetryAttempts, updateInput.RetryDelaySeconds);
+        entity.SetSettingsJson(updateInput.SettingsJson);
+        entity.SetCategory(updateInput.Category);
+        entity.UpdateActivation(updateInput.IsActive);
+        entity.SetCurrentStatus(updateInput.CurrentStatus);
+        entity.SetLastCheckedAt(updateInput.LastCheckedAt);
+        entity.SetLastStatusChangeAt(updateInput.LastStatusChangeAt);
+        entity.SetNextDueAt(updateInput.NextDueAt);
+        entity.SetConsecutiveFailures(updateInput.ConsecutiveFailures);
+        entity.SetFirstDownAt(updateInput.FirstDownAt);
+        entity.SetLastUpAt(updateInput.LastUpAt);
+    }
+
+    public async Task TriggerCheckAsync(Guid id)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
+
+        var cancellationToken = CancellationTokenProvider.Token;
+        var entity = await Repository.GetAsync(id, cancellationToken: cancellationToken);
+
+        var now = Clock.Now;
+        entity.SetLastCheckedAt(now);
+        entity.SetNextDueAt(now.AddSeconds(entity.CheckIntervalSeconds));
+        entity.SetCurrentStatus(ServiceStatus.Checking);
+        entity.SetLastStatusChangeAt(now);
+        entity.SetConsecutiveFailures(0);
+
+        await Repository.UpdateAsync(entity, autoSave: true, cancellationToken: cancellationToken);
+    }
+
+    public async Task<HealthCheckResultDto> CheckNowAsync(Guid id)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
+
+        var cancellationToken = CancellationTokenProvider.Token;
+        var target = await Repository.GetAsync(id, cancellationToken: cancellationToken);
+
+        var (result, timestamp) = await ExecuteCheckAsync(target, ManualTriggerSource, cancellationToken);
+
+        await Repository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
+
+        return CreateResultDto(target, result, timestamp);
+    }
+
+    public async Task<List<HealthCheckResultDto>> CheckAllAsync()
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
+
+        var cancellationToken = CancellationTokenProvider.Token;
+        var targets = await Repository.GetListAsync(target => target.IsActive, cancellationToken: cancellationToken);
+
+        var results = new List<HealthCheckResultDto>(targets.Count);
+
+        foreach (var target in targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var (result, timestamp) = await ExecuteCheckAsync(target, BulkTriggerSource, cancellationToken);
+            await Repository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
+
+            results.Add(CreateResultDto(target, result, timestamp));
+        }
+
+        return results;
+    }
+
+    private async Task<(HealthCheckResult Result, DateTime Timestamp)> ExecuteCheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken)
+    {
+        HealthCheckResult result;
+        try
+        {
+            var provider = _providerResolver.Resolve(target.Type);
+            result = await provider.CheckAsync(target, triggerSource, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Monitoring check failed for target {TargetId}", target.Id);
+            result = new HealthCheckResult(false, null, "Check error", triggerSource);
+        }
+
+        var timestamp = Clock.Now;
+        MonitoringTargetCheckProcessor.ApplyResult(target, result, timestamp);
+
+        return (result, timestamp);
+    }
+
+    private static HealthCheckResultDto CreateResultDto(
+        MonitoringTarget target,
+        HealthCheckResult result,
+        DateTime timestamp)
+    {
+        return new HealthCheckResultDto
+        {
+            TargetId = target.Id,
+            Status = target.CurrentStatus,
+            ResponseTimeMs = result.ResponseTimeMs,
+            ErrorSummary = result.ErrorSummary,
+            CheckedAt = timestamp
+        };
+    }
+}

--- a/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetAppService.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Monitoring.HealthChecks;
 using Monitoring.Permissions;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Authorization;
@@ -15,13 +17,17 @@ using Volo.Abp.Guids;
 
 namespace Monitoring.Targets;
 
-public class MonitoringTargetAppService :
-    CrudAppService<MonitoringTarget, MonitoringTargetDto, Guid, PagedAndSortedResultRequestDto, CreateUpdateMonitoringTargetDto>,
-    IMonitoringTargetAppService
+public class MonitoringTargetAppService : ApplicationService, IMonitoringTargetAppService
 {
-    private const string ManualTriggerSource = "manual";
-    private const string BulkTriggerSource = "api";
+    private const int DefaultPageSize = 12;
+    private const int MaxPageSize = 100;
 
+    private static readonly JsonSerializerOptions SettingsSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IRepository<MonitoringTarget, Guid> _repository;
     private readonly IHealthCheckProviderResolver _providerResolver;
     private readonly IRepository<ServiceStatusHistory, Guid> _historyRepository;
     private readonly IRepository<OutageWindow, Guid> _outageRepository;
@@ -33,71 +39,132 @@ public class MonitoringTargetAppService :
         IRepository<ServiceStatusHistory, Guid> historyRepository,
         IRepository<OutageWindow, Guid> outageRepository,
         IGuidGenerator guidGenerator)
-        : base(repository)
     {
+        _repository = repository;
         _providerResolver = providerResolver;
         _historyRepository = historyRepository;
         _outageRepository = outageRepository;
         _guidGenerator = guidGenerator;
-        GetPolicyName = MonitoringPermissions.Services.View;
-        GetListPolicyName = MonitoringPermissions.Services.View;
-        CreatePolicyName = MonitoringPermissions.Services.Create;
-        UpdatePolicyName = MonitoringPermissions.Services.Edit;
-        DeletePolicyName = MonitoringPermissions.Services.Delete;
     }
 
-    protected override MonitoringTarget MapToEntity(CreateUpdateMonitoringTargetDto createInput)
+    public async Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(
+        PagedAndSortedResultRequestDto input,
+        ServiceType? type = null,
+        string? search = null)
     {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+
+        var maxResultCount = input.MaxResultCount <= 0
+            ? DefaultPageSize
+            : Math.Min(input.MaxResultCount, MaxPageSize);
+        var skipCount = input.SkipCount < 0 ? 0 : input.SkipCount;
+
+        var queryable = await _repository.GetQueryableAsync();
+
+        if (type.HasValue)
+        {
+            queryable = queryable.Where(target => target.Type == type.Value);
+        }
+
+        if (!search.IsNullOrWhiteSpace())
+        {
+            var term = search!.Trim();
+            queryable = queryable.Where(target => target.Name.Contains(term) || target.Endpoint.Contains(term));
+        }
+
+        queryable = ApplySorting(queryable, input.Sorting);
+
+        var totalCount = await AsyncExecuter.CountAsync(queryable);
+        var items = await AsyncExecuter.ToListAsync(
+            queryable
+                .Skip(skipCount)
+                .Take(maxResultCount));
+
+        var dtos = ObjectMapper.Map<List<MonitoringTarget>, List<MonitoringTargetDto>>(items);
+        return new PagedResultDto<MonitoringTargetDto>(totalCount, dtos);
+    }
+
+    public async Task<MonitoringTargetDto> GetAsync(Guid id)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
+        var entity = await _repository.GetAsync(id);
+        return ObjectMapper.Map<MonitoringTarget, MonitoringTargetDto>(entity);
+    }
+
+    public async Task<MonitoringTargetDto> CreateAsync(CreateUpdateMonitoringTargetDto input)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Create);
+        ValidateInput(input);
+
+        var now = Clock.Now;
         var entity = new MonitoringTarget(
-            GuidGenerator.Create(),
-            createInput.Name,
-            createInput.Type,
-            createInput.Endpoint,
-            createInput.CheckIntervalSeconds,
-            createInput.TimeoutSeconds,
-            createInput.MaxRetryAttempts,
-            createInput.RetryDelaySeconds,
-            createInput.IsActive,
-            createInput.CurrentStatus,
-            createInput.NextDueAt,
-            createInput.SettingsJson,
-            createInput.Category
-        );
+            _guidGenerator.Create(),
+            input.Name,
+            input.Type,
+            input.Endpoint,
+            input.CheckIntervalSeconds,
+            input.TimeoutSeconds,
+            input.MaxRetryAttempts,
+            input.RetryDelaySeconds,
+            input.IsActive,
+            ServiceStatus.Checking,
+            now,
+            input.SettingsJson,
+            input.Category);
 
-        entity.SetLastCheckedAt(createInput.LastCheckedAt);
-        entity.SetLastStatusChangeAt(createInput.LastStatusChangeAt);
-        entity.SetConsecutiveFailures(createInput.ConsecutiveFailures);
-        entity.SetFirstDownAt(createInput.FirstDownAt);
-        entity.SetLastUpAt(createInput.LastUpAt);
+        entity.SetConsecutiveFailures(0);
+        entity.SetLastCheckedAt(null);
+        entity.SetLastStatusChangeAt(now);
+        entity.SetFirstDownAt(null);
+        entity.SetLastUpAt(null);
 
-        return entity;
+        var created = await _repository.InsertAsync(entity, autoSave: true);
+        return ObjectMapper.Map<MonitoringTarget, MonitoringTargetDto>(created);
     }
 
-    protected override void MapToEntity(CreateUpdateMonitoringTargetDto updateInput, MonitoringTarget entity)
+    public async Task<MonitoringTargetDto> UpdateAsync(Guid id, CreateUpdateMonitoringTargetDto input)
     {
-        entity.SetName(updateInput.Name);
-        entity.SetType(updateInput.Type);
-        entity.SetEndpoint(updateInput.Endpoint);
-        entity.UpdateCheckIntervalSeconds(updateInput.CheckIntervalSeconds);
-        entity.UpdateTimeoutSeconds(updateInput.TimeoutSeconds);
-        entity.UpdateRetrySettings(updateInput.MaxRetryAttempts, updateInput.RetryDelaySeconds);
-        entity.SetSettingsJson(updateInput.SettingsJson);
-        entity.SetCategory(updateInput.Category);
-        entity.UpdateActivation(updateInput.IsActive);
-        entity.SetCurrentStatus(updateInput.CurrentStatus);
-        entity.SetLastCheckedAt(updateInput.LastCheckedAt);
-        entity.SetLastStatusChangeAt(updateInput.LastStatusChangeAt);
-        entity.SetNextDueAt(updateInput.NextDueAt);
-        entity.SetConsecutiveFailures(updateInput.ConsecutiveFailures);
-        entity.SetFirstDownAt(updateInput.FirstDownAt);
-        entity.SetLastUpAt(updateInput.LastUpAt);
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Edit);
+        ValidateInput(input);
+
+        var entity = await _repository.GetAsync(id);
+        var typeChanged = entity.Type != input.Type;
+
+        entity.SetName(input.Name);
+        entity.SetType(input.Type);
+        entity.SetEndpoint(input.Endpoint);
+        entity.UpdateCheckIntervalSeconds(input.CheckIntervalSeconds);
+        entity.UpdateTimeoutSeconds(input.TimeoutSeconds);
+        entity.UpdateRetrySettings(input.MaxRetryAttempts, input.RetryDelaySeconds);
+        entity.SetSettingsJson(input.SettingsJson);
+        entity.SetCategory(input.Category);
+        entity.UpdateActivation(input.IsActive);
+
+        if (typeChanged)
+        {
+            entity.SetCurrentStatus(ServiceStatus.Checking);
+            entity.SetConsecutiveFailures(0);
+            entity.SetFirstDownAt(null);
+            entity.SetLastStatusChangeAt(Clock.Now);
+        }
+
+        entity.SetNextDueAt(Clock.Now.AddSeconds(input.CheckIntervalSeconds));
+
+        var updated = await _repository.UpdateAsync(entity, autoSave: true);
+        return ObjectMapper.Map<MonitoringTarget, MonitoringTargetDto>(updated);
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Delete);
+        await _repository.DeleteAsync(id);
     }
 
     public async Task TriggerCheckAsync(Guid id)
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var entity = await Repository.GetAsync(id);
+        var entity = await _repository.GetAsync(id);
 
         var now = Clock.Now;
         entity.SetLastCheckedAt(now);
@@ -106,20 +173,20 @@ public class MonitoringTargetAppService :
         entity.SetLastStatusChangeAt(now);
         entity.SetConsecutiveFailures(0);
 
-        await Repository.UpdateAsync(entity, autoSave: true);
+        await _repository.UpdateAsync(entity, autoSave: true);
     }
 
     public async Task<HealthCheckResultDto> CheckNowAsync(Guid id)
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var target = await Repository.GetAsync(id);
+        var target = await _repository.GetAsync(id);
 
-        var execution = await ExecuteCheckAsync(target, ManualTriggerSource);
+        var execution = await ExecuteCheckAsync(target, "manual");
         var result = execution.Result;
         var timestamp = execution.Timestamp;
 
-        await Repository.UpdateAsync(target, autoSave: true);
+        await _repository.UpdateAsync(target, autoSave: true);
 
         return CreateResultDto(target, result, timestamp);
     }
@@ -128,14 +195,14 @@ public class MonitoringTargetAppService :
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var targets = await Repository.GetListAsync(target => target.IsActive);
+        var targets = await _repository.GetListAsync(target => target.IsActive);
 
         var results = new List<HealthCheckResultDto>(targets.Count);
 
         foreach (var target in targets)
         {
-            var execution = await ExecuteCheckAsync(target, BulkTriggerSource);
-            await Repository.UpdateAsync(target, autoSave: true);
+            var execution = await ExecuteCheckAsync(target, "api");
+            await _repository.UpdateAsync(target, autoSave: true);
 
             results.Add(CreateResultDto(target, execution.Result, execution.Timestamp));
         }
@@ -147,7 +214,7 @@ public class MonitoringTargetAppService :
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.Run);
 
-        var targets = await Repository.GetListAsync(target => target.IsActive);
+        var targets = await _repository.GetListAsync(target => target.IsActive);
         var now = Clock.Now;
 
         foreach (var target in targets)
@@ -162,7 +229,7 @@ public class MonitoringTargetAppService :
             target.SetNextDueAt(now);
             target.SetConsecutiveFailures(0);
 
-            await Repository.UpdateAsync(target, autoSave: true);
+            await _repository.UpdateAsync(target, autoSave: true);
         }
 
         return targets.Count;
@@ -172,7 +239,7 @@ public class MonitoringTargetAppService :
     {
         await AuthorizationService.CheckAsync(MonitoringPermissions.Services.View);
 
-        var queryable = await Repository.GetQueryableAsync();
+        var queryable = await _repository.GetQueryableAsync();
 
         if (type.HasValue)
         {
@@ -216,6 +283,187 @@ public class MonitoringTargetAppService :
                 .Take(normalizedCount));
 
         return ObjectMapper.Map<List<ServiceStatusHistory>, List<ServiceStatusHistoryDto>>(history);
+    }
+
+    private IQueryable<MonitoringTarget> ApplySorting(IQueryable<MonitoringTarget> query, string? sorting)
+    {
+        if (sorting.IsNullOrWhiteSpace())
+        {
+            return query.OrderBy(target => target.Name);
+        }
+
+        var normalized = sorting!.Trim();
+        var lower = normalized.ToLowerInvariant();
+
+        return lower switch
+        {
+            "name desc" or "name descending" => query.OrderByDescending(target => target.Name),
+            "name" or "name asc" => query.OrderBy(target => target.Name),
+            "lastcheckedat desc" or "lastcheckedat" or "lastcheckedat descending" => query.OrderByDescending(target => target.LastCheckedAt),
+            "nextdueat" or "nextdueat asc" => query.OrderBy(target => target.NextDueAt),
+            "nextdueat desc" or "nextdueat descending" => query.OrderByDescending(target => target.NextDueAt),
+            _ => query.OrderBy(target => target.Name)
+        };
+    }
+
+    private void ValidateInput(CreateUpdateMonitoringTargetDto input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        if (input.Name.IsNullOrWhiteSpace() || input.Name.Length is < 2 or > 128)
+        {
+            throw new UserFriendlyException("Name must be between 2 and 128 characters.");
+        }
+
+        if (input.Endpoint.IsNullOrWhiteSpace())
+        {
+            throw new UserFriendlyException("Endpoint is required.");
+        }
+
+        if (input.CheckIntervalSeconds < 10)
+        {
+            throw new UserFriendlyException("Check interval must be at least 10 seconds.");
+        }
+
+        if (input.TimeoutSeconds <= 0)
+        {
+            throw new UserFriendlyException("Timeout must be greater than zero.");
+        }
+
+        if (input.RetryDelaySeconds < 1)
+        {
+            throw new UserFriendlyException("Retry delay must be at least 1 second.");
+        }
+
+        if (input.MaxRetryAttempts < 0)
+        {
+            throw new UserFriendlyException("Retry attempts cannot be negative.");
+        }
+
+        ValidateEndpointAndSettings(input);
+    }
+
+    private void ValidateEndpointAndSettings(CreateUpdateMonitoringTargetDto input)
+    {
+        switch (input.Type)
+        {
+            case ServiceType.Website:
+                EnsureValidHttpEndpoint(input.Endpoint);
+                DeserializeSettings<WebsiteSettings>(input.SettingsJson, "Website settings");
+                break;
+            case ServiceType.Api:
+                EnsureValidHttpEndpoint(input.Endpoint);
+                DeserializeSettings<ApiSettings>(input.SettingsJson, "API settings");
+                break;
+            case ServiceType.Tcp:
+                ValidateTcpConfiguration(input.Endpoint, input.SettingsJson);
+                break;
+            case ServiceType.Redis:
+                ValidateRedisConfiguration(input.Endpoint, input.SettingsJson);
+                break;
+            default:
+                throw new UserFriendlyException("Unsupported service type.");
+        }
+    }
+
+    private void ValidateTcpConfiguration(string endpoint, string? settingsJson)
+    {
+        if (EndpointParser.TryParseHostPort(endpoint, out _, out _))
+        {
+            DeserializeSettings<TcpSettings>(settingsJson, "TCP settings");
+            return;
+        }
+
+        var settings = DeserializeSettings<TcpSettings>(settingsJson, "TCP settings");
+        if (settings.Host.IsNullOrWhiteSpace() || !settings.Port.HasValue || settings.Port.Value is < 1 or > 65535)
+        {
+            throw new UserFriendlyException("Provide a valid host and port for TCP targets.");
+        }
+    }
+
+    private void ValidateRedisConfiguration(string endpoint, string? settingsJson)
+    {
+        var endpointValid = EndpointParser.TryParseHostPort(endpoint, out _, out _);
+        var settings = DeserializeSettings<RedisSettings>(settingsJson, "Redis settings");
+
+        if (settings.Endpoints is { Length: > 0 })
+        {
+            foreach (var candidate in settings.Endpoints)
+            {
+                if (!EndpointParser.TryParseHostPort(candidate, out _, out _))
+                {
+                    throw new UserFriendlyException("Redis endpoints must be expressed as host:port values.");
+                }
+            }
+        }
+
+        var mode = settings.Mode?.Trim().ToLowerInvariant() ?? "standalone";
+        if (mode == "sentinel")
+        {
+            if (settings.Sentinels == null || settings.Sentinels.Length == 0)
+            {
+                throw new UserFriendlyException("Sentinel configuration requires at least one sentinel endpoint.");
+            }
+
+            foreach (var sentinel in settings.Sentinels)
+            {
+                if (!EndpointParser.TryParseHostPort(sentinel, out _, out _))
+                {
+                    throw new UserFriendlyException("Sentinel endpoints must be valid host:port values.");
+                }
+            }
+
+            if (settings.SentinelMasterName.IsNullOrWhiteSpace())
+            {
+                throw new UserFriendlyException("Sentinel master name is required.");
+            }
+        }
+
+        if (!endpointValid)
+        {
+            var hasEndpoint = settings.Endpoints != null && settings.Endpoints.Any(e => EndpointParser.TryParseHostPort(e, out _, out _));
+            if (!hasEndpoint)
+            {
+                throw new UserFriendlyException("Provide at least one valid Redis endpoint.");
+            }
+        }
+    }
+
+    private static void EnsureValidHttpEndpoint(string endpoint)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new UserFriendlyException("Endpoint must be an absolute HTTP or HTTPS URL.");
+        }
+    }
+
+    private T DeserializeSettings<T>(string? json, string context)
+        where T : class, new()
+    {
+        if (json.IsNullOrWhiteSpace())
+        {
+            return new T();
+        }
+
+        try
+        {
+            var settings = JsonSerializer.Deserialize<T>(json, SettingsSerializerOptions);
+            if (settings == null)
+            {
+                throw new UserFriendlyException($"{context} JSON is invalid.");
+            }
+
+            return settings;
+        }
+        catch (JsonException ex)
+        {
+            Logger.LogWarning(ex, "Failed to deserialize monitoring settings for {Context}", context);
+            throw new UserFriendlyException($"{context} JSON is invalid.");
+        }
     }
 
     private async Task<(HealthCheckResult Result, DateTime Timestamp)> ExecuteCheckAsync(

--- a/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
@@ -14,7 +14,7 @@ internal static class MonitoringTargetCheckProcessor
     private const string LastErrorSummaryPropertyName = "Monitoring:LastErrorSummary";
     private const string LastTriggerSourcePropertyName = "Monitoring:LastTriggerSource";
 
-    public static async Task ApplyResultAsync(
+    public static async Task<MonitoringCheckOutcome> ApplyResultAsync(
         MonitoringTarget target,
         HealthCheckResult result,
         DateTime timestamp,
@@ -82,7 +82,7 @@ internal static class MonitoringTargetCheckProcessor
             await historyRepository.InsertAsync(history, autoSave: true, cancellationToken);
         }
 
-        await ManageOutageWindowAsync(
+        var outageTransition = await ManageOutageWindowAsync(
             target,
             previousStatus,
             newStatus,
@@ -90,9 +90,17 @@ internal static class MonitoringTargetCheckProcessor
             outageRepository,
             guidGenerator,
             cancellationToken);
+
+        return new MonitoringCheckOutcome(
+            previousStatus,
+            newStatus,
+            outageTransition.ActiveOutage,
+            outageTransition.ClosedOutage,
+            outageTransition.OutageStarted,
+            outageTransition.OutageClosed);
     }
 
-    private static async Task ManageOutageWindowAsync(
+    private static async Task<OutageTransitionResult> ManageOutageWindowAsync(
         MonitoringTarget target,
         ServiceStatus previousStatus,
         ServiceStatus newStatus,
@@ -101,6 +109,11 @@ internal static class MonitoringTargetCheckProcessor
         IGuidGenerator guidGenerator,
         CancellationToken cancellationToken)
     {
+        OutageWindow? activeOutage = null;
+        OutageWindow? closedOutage = null;
+        var outageStarted = false;
+        var outageClosed = false;
+
         if (newStatus == ServiceStatus.Offline)
         {
             var outage = await outageRepository.FirstOrDefaultAsync(
@@ -118,11 +131,15 @@ internal static class MonitoringTargetCheckProcessor
                         failureCount: 1);
 
                     await outageRepository.InsertAsync(newOutage, autoSave: true, cancellationToken);
+                    activeOutage = newOutage;
+                    outageStarted = true;
                 }
                 else
                 {
                     outage.MarkAsStarted(timestamp, 1);
                     await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+                    activeOutage = outage;
+                    outageStarted = true;
                 }
             }
             else
@@ -136,11 +153,14 @@ internal static class MonitoringTargetCheckProcessor
                         failureCount: 1);
 
                     await outageRepository.InsertAsync(newOutage, autoSave: true, cancellationToken);
+                    activeOutage = newOutage;
+                    outageStarted = true;
                 }
                 else
                 {
                     outage.IncrementFailure();
                     await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+                    activeOutage = outage;
                 }
             }
         }
@@ -154,7 +174,57 @@ internal static class MonitoringTargetCheckProcessor
             {
                 outage.Close(timestamp);
                 await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+                closedOutage = outage;
+                outageClosed = true;
             }
         }
+
+        return new OutageTransitionResult(activeOutage, closedOutage, outageStarted, outageClosed);
     }
+}
+
+internal sealed class MonitoringCheckOutcome
+{
+    public MonitoringCheckOutcome(
+        ServiceStatus previousStatus,
+        ServiceStatus currentStatus,
+        OutageWindow? activeOutage,
+        OutageWindow? closedOutage,
+        bool outageStarted,
+        bool outageClosed)
+    {
+        PreviousStatus = previousStatus;
+        CurrentStatus = currentStatus;
+        ActiveOutage = activeOutage;
+        ClosedOutage = closedOutage;
+        OutageStarted = outageStarted;
+        OutageClosed = outageClosed;
+    }
+
+    public ServiceStatus PreviousStatus { get; }
+    public ServiceStatus CurrentStatus { get; }
+    public OutageWindow? ActiveOutage { get; }
+    public OutageWindow? ClosedOutage { get; }
+    public bool OutageStarted { get; }
+    public bool OutageClosed { get; }
+}
+
+internal sealed class OutageTransitionResult
+{
+    public OutageTransitionResult(
+        OutageWindow? activeOutage,
+        OutageWindow? closedOutage,
+        bool outageStarted,
+        bool outageClosed)
+    {
+        ActiveOutage = activeOutage;
+        ClosedOutage = closedOutage;
+        OutageStarted = outageStarted;
+        OutageClosed = outageClosed;
+    }
+
+    public OutageWindow? ActiveOutage { get; }
+    public OutageWindow? ClosedOutage { get; }
+    public bool OutageStarted { get; }
+    public bool OutageClosed { get; }
 }

--- a/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
@@ -1,0 +1,62 @@
+using System;
+using Monitoring.HealthChecks;
+using Volo.Abp.Data;
+
+namespace Monitoring.Targets;
+
+internal static class MonitoringTargetCheckProcessor
+{
+    private const string LastResponseTimePropertyName = "Monitoring:LastResponseTimeMs";
+    private const string LastErrorSummaryPropertyName = "Monitoring:LastErrorSummary";
+    private const string LastTriggerSourcePropertyName = "Monitoring:LastTriggerSource";
+
+    public static void ApplyResult(MonitoringTarget target, HealthCheckResult result, DateTime timestamp)
+    {
+        var previousStatus = target.CurrentStatus;
+
+        target.SetLastCheckedAt(timestamp);
+        target.SetProperty(LastResponseTimePropertyName, result.ResponseTimeMs);
+        target.SetProperty(LastErrorSummaryPropertyName, result.ErrorSummary);
+        target.SetProperty(LastTriggerSourcePropertyName, result.TriggerSource);
+
+        ServiceStatus newStatus;
+
+        if (result.IsSuccess)
+        {
+            newStatus = ServiceStatus.Online;
+            target.SetConsecutiveFailures(0);
+            target.SetLastUpAt(timestamp);
+            target.SetNextDueAt(timestamp.AddSeconds(target.CheckIntervalSeconds));
+            target.SetFirstDownAt(null);
+        }
+        else
+        {
+            var failures = target.ConsecutiveFailures + 1;
+            target.SetConsecutiveFailures(failures);
+
+            if (failures < target.MaxRetryAttempts)
+            {
+                newStatus = ServiceStatus.Checking;
+                var retryDelaySeconds = target.RetryDelaySeconds > 0 ? target.RetryDelaySeconds : 1;
+                target.SetNextDueAt(timestamp.AddSeconds(retryDelaySeconds));
+            }
+            else
+            {
+                newStatus = ServiceStatus.Offline;
+                target.SetNextDueAt(timestamp.AddSeconds(target.CheckIntervalSeconds));
+
+                if (!target.FirstDownAt.HasValue)
+                {
+                    target.SetFirstDownAt(timestamp);
+                }
+            }
+        }
+
+        target.SetCurrentStatus(newStatus);
+
+        if (newStatus != previousStatus)
+        {
+            target.SetLastStatusChangeAt(timestamp);
+        }
+    }
+}

--- a/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
+++ b/src/Monitoring.Application/Targets/MonitoringTargetCheckProcessor.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Monitoring.HealthChecks;
 using Volo.Abp.Data;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Guids;
 
 namespace Monitoring.Targets;
 
@@ -10,7 +14,14 @@ internal static class MonitoringTargetCheckProcessor
     private const string LastErrorSummaryPropertyName = "Monitoring:LastErrorSummary";
     private const string LastTriggerSourcePropertyName = "Monitoring:LastTriggerSource";
 
-    public static void ApplyResult(MonitoringTarget target, HealthCheckResult result, DateTime timestamp)
+    public static async Task ApplyResultAsync(
+        MonitoringTarget target,
+        HealthCheckResult result,
+        DateTime timestamp,
+        IRepository<ServiceStatusHistory, Guid> historyRepository,
+        IRepository<OutageWindow, Guid> outageRepository,
+        IGuidGenerator guidGenerator,
+        CancellationToken cancellationToken = default)
     {
         var previousStatus = target.CurrentStatus;
 
@@ -57,6 +68,93 @@ internal static class MonitoringTargetCheckProcessor
         if (newStatus != previousStatus)
         {
             target.SetLastStatusChangeAt(timestamp);
+
+            var history = new ServiceStatusHistory(
+                guidGenerator.Create(),
+                target.Id,
+                previousStatus,
+                newStatus,
+                timestamp,
+                result.TriggerSource,
+                result.ResponseTimeMs,
+                result.ErrorSummary);
+
+            await historyRepository.InsertAsync(history, autoSave: true, cancellationToken);
+        }
+
+        await ManageOutageWindowAsync(
+            target,
+            previousStatus,
+            newStatus,
+            timestamp,
+            outageRepository,
+            guidGenerator,
+            cancellationToken);
+    }
+
+    private static async Task ManageOutageWindowAsync(
+        MonitoringTarget target,
+        ServiceStatus previousStatus,
+        ServiceStatus newStatus,
+        DateTime timestamp,
+        IRepository<OutageWindow, Guid> outageRepository,
+        IGuidGenerator guidGenerator,
+        CancellationToken cancellationToken)
+    {
+        if (newStatus == ServiceStatus.Offline)
+        {
+            var outage = await outageRepository.FirstOrDefaultAsync(
+                x => x.TargetId == target.Id && x.EndedAt == null,
+                cancellationToken: cancellationToken);
+
+            if (previousStatus != ServiceStatus.Offline)
+            {
+                if (outage == null)
+                {
+                    var newOutage = new OutageWindow(
+                        guidGenerator.Create(),
+                        target.Id,
+                        timestamp,
+                        failureCount: 1);
+
+                    await outageRepository.InsertAsync(newOutage, autoSave: true, cancellationToken);
+                }
+                else
+                {
+                    outage.MarkAsStarted(timestamp, 1);
+                    await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+                }
+            }
+            else
+            {
+                if (outage == null)
+                {
+                    var newOutage = new OutageWindow(
+                        guidGenerator.Create(),
+                        target.Id,
+                        timestamp,
+                        failureCount: 1);
+
+                    await outageRepository.InsertAsync(newOutage, autoSave: true, cancellationToken);
+                }
+                else
+                {
+                    outage.IncrementFailure();
+                    await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+                }
+            }
+        }
+        else if (previousStatus == ServiceStatus.Offline)
+        {
+            var outage = await outageRepository.FirstOrDefaultAsync(
+                x => x.TargetId == target.Id && x.EndedAt == null,
+                cancellationToken: cancellationToken);
+
+            if (outage != null)
+            {
+                outage.Close(timestamp);
+                await outageRepository.UpdateAsync(outage, autoSave: true, cancellationToken);
+            }
         }
     }
 }

--- a/src/Monitoring.Application/Workers/MonitoringWorker.cs
+++ b/src/Monitoring.Application/Workers/MonitoringWorker.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Monitoring.HealthChecks;
+using Monitoring.Targets;
+using Volo.Abp.BackgroundWorkers;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Timing;
+using Volo.Abp.Uow;
+using Volo.Abp.Threading;
+
+namespace Monitoring.Workers;
+
+public class MonitoringWorker : AsyncPeriodicBackgroundWorkerBase, ISingletonDependency
+{
+    private const string TriggerSource = "worker";
+    private static readonly TimeSpan OverrideInterval = TimeSpan.FromMinutes(30);
+
+    private readonly IRepository<MonitoringTarget, Guid> _targetRepository;
+    private readonly IHealthCheckProviderResolver _providerResolver;
+    private readonly IClock _clock;
+
+    public MonitoringWorker(
+        AbpAsyncTimer timer,
+        IServiceScopeFactory serviceScopeFactory,
+        IRepository<MonitoringTarget, Guid> targetRepository,
+        IHealthCheckProviderResolver providerResolver,
+        IClock clock)
+        : base(timer, serviceScopeFactory)
+    {
+        _targetRepository = targetRepository;
+        _providerResolver = providerResolver;
+        _clock = clock;
+
+        Timer.Period = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+        Timer.RunOnStart = true;
+    }
+
+    protected override async Task DoWorkAsync(PeriodicBackgroundWorkerContext workerContext)
+    {
+        var cancellationToken = workerContext.CancellationToken;
+
+        var uowOptions = new AbpUnitOfWorkOptions
+        {
+            IsTransactional = false
+        };
+
+        using var uow = UnitOfWorkManager.Begin(uowOptions, requiresNew: true);
+
+        var now = _clock.Now;
+        var overrideThreshold = now - OverrideInterval;
+
+        var targets = await _targetRepository.GetListAsync(
+            target => target.IsActive &&
+                (target.NextDueAt <= now ||
+                 !target.LastCheckedAt.HasValue ||
+                 target.LastCheckedAt <= overrideThreshold),
+            cancellationToken: cancellationToken);
+
+        foreach (var target in targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await HandleTargetAsync(target, cancellationToken);
+        }
+
+        await uow.CompleteAsync();
+    }
+
+    private async Task HandleTargetAsync(MonitoringTarget target, CancellationToken cancellationToken)
+    {
+        HealthCheckResult result;
+        try
+        {
+            var provider = _providerResolver.Resolve(target.Type);
+            result = await provider.CheckAsync(target, TriggerSource, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Monitoring worker failed for target {TargetId}", target.Id);
+            result = new HealthCheckResult(false, null, "Worker error", TriggerSource);
+        }
+
+        var recordedAt = _clock.Now;
+
+        MonitoringTargetCheckProcessor.ApplyResult(target, result, recordedAt);
+
+        await _targetRepository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Monitoring.Application/Workers/MonitoringWorker.cs
+++ b/src/Monitoring.Application/Workers/MonitoringWorker.cs
@@ -1,14 +1,20 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Monitoring.Alerts;
 using Monitoring.HealthChecks;
+using Monitoring.Options;
 using Monitoring.Targets;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
+using Volo.Abp;
 
 namespace Monitoring.Workers;
 
@@ -22,29 +28,41 @@ public class MonitoringWorker : BackgroundService
     private readonly IRepository<MonitoringTarget, Guid> _targetRepository;
     private readonly IRepository<ServiceStatusHistory, Guid> _historyRepository;
     private readonly IRepository<OutageWindow, Guid> _outageRepository;
+    private readonly IRepository<AlertPolicy, Guid> _alertPolicyRepository;
+    private readonly IRepository<MaintenanceWindow, Guid> _maintenanceRepository;
     private readonly IHealthCheckProviderResolver _providerResolver;
+    private readonly INotificationChannelResolver _channelResolver;
     private readonly IClock _clock;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly IGuidGenerator _guidGenerator;
+    private readonly MonitoringOptions _options;
 
     public MonitoringWorker(
         ILogger<MonitoringWorker> logger,
         IRepository<MonitoringTarget, Guid> targetRepository,
         IRepository<ServiceStatusHistory, Guid> historyRepository,
         IRepository<OutageWindow, Guid> outageRepository,
+        IRepository<AlertPolicy, Guid> alertPolicyRepository,
+        IRepository<MaintenanceWindow, Guid> maintenanceRepository,
         IHealthCheckProviderResolver providerResolver,
+        INotificationChannelResolver channelResolver,
         IClock clock,
         IUnitOfWorkManager unitOfWorkManager,
-        IGuidGenerator guidGenerator)
+        IGuidGenerator guidGenerator,
+        IOptions<MonitoringOptions> options)
     {
         _logger = logger;
         _targetRepository = targetRepository;
         _historyRepository = historyRepository;
         _outageRepository = outageRepository;
+        _alertPolicyRepository = alertPolicyRepository;
+        _maintenanceRepository = maintenanceRepository;
         _providerResolver = providerResolver;
+        _channelResolver = channelResolver;
         _clock = clock;
         _unitOfWorkManager = unitOfWorkManager;
         _guidGenerator = guidGenerator;
+        _options = options.Value;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -91,6 +109,8 @@ public class MonitoringWorker : BackgroundService
     private async Task HandleTargetAsync(MonitoringTarget target, CancellationToken cancellationToken)
     {
         HealthCheckResult result;
+        var previousStatus = target.CurrentStatus;
+        var previousLastUpAt = target.LastUpAt;
         try
         {
             var provider = _providerResolver.Resolve(target.Type);
@@ -105,7 +125,7 @@ public class MonitoringWorker : BackgroundService
         using var uow = _unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
 
         var recordedAt = _clock.Now;
-        await MonitoringTargetCheckProcessor.ApplyResultAsync(
+        var outcome = await MonitoringTargetCheckProcessor.ApplyResultAsync(
             target,
             result,
             recordedAt,
@@ -114,7 +134,210 @@ public class MonitoringWorker : BackgroundService
             _guidGenerator,
             cancellationToken);
 
+        var alertDispatches = await EvaluateAlertsAsync(
+            target,
+            outcome,
+            result,
+            recordedAt,
+            previousLastUpAt,
+            cancellationToken);
+
         await _targetRepository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
         await uow.CompleteAsync();
+
+        if (alertDispatches.Count > 0)
+        {
+            await DispatchAlertsAsync(alertDispatches, cancellationToken);
+        }
+    }
+
+    private async Task<List<AlertDispatch>> EvaluateAlertsAsync(
+        MonitoringTarget target,
+        MonitoringCheckOutcome outcome,
+        HealthCheckResult result,
+        DateTime timestamp,
+        DateTime? previousLastUpAt,
+        CancellationToken cancellationToken)
+    {
+        var dispatches = new List<AlertDispatch>();
+
+        var policy = await _alertPolicyRepository.FirstOrDefaultAsync(x => x.TargetId == target.Id, cancellationToken: cancellationToken);
+        var defaults = _options.AlertDefaults;
+
+        var enabled = policy?.Enabled ?? defaults.Enabled;
+        var notifyAfterFailures = policy?.NotifyAfterFailures ?? defaults.NotifyAfterFailures;
+        var repeatMinutes = policy?.RepeatMinutes ?? defaults.RepeatMinutes;
+        var recoverQuietMinutes = policy?.RecoverQuietMinutes ?? defaults.RecoverQuietMinutes;
+        var suppressDuringMaintenance = policy?.SuppressDuringMaintenance ?? defaults.SuppressDuringMaintenance;
+
+        var channels = ResolveChannels(policy?.ChannelsJson);
+        if (channels.Count == 0)
+        {
+            var fallback = _options.AlertDefaults.DefaultChannels ?? new Dictionary<string, string[]>();
+            channels = CloneChannels(fallback);
+        }
+
+        if (channels.Count == 0)
+        {
+            return dispatches;
+        }
+
+        var underMaintenance = suppressDuringMaintenance && await HasActiveMaintenanceAsync(target.Id, timestamp, cancellationToken);
+
+        var evaluation = AlertEvaluator.Evaluate(new AlertEvaluationInput(
+            outcome.PreviousStatus,
+            outcome.CurrentStatus,
+            target.ConsecutiveFailures,
+            timestamp,
+            notifyAfterFailures,
+            repeatMinutes,
+            recoverQuietMinutes,
+            enabled,
+            underMaintenance,
+            outcome.ActiveOutage,
+            outcome.ClosedOutage,
+            previousLastUpAt));
+
+        if (evaluation.EventType == null)
+        {
+            return dispatches;
+        }
+
+        OutageWindow? outageForAlert = evaluation.Outage;
+        if (evaluation.ShouldRecordAlert && outageForAlert != null)
+        {
+            outageForAlert.RecordAlert(timestamp);
+            await _outageRepository.UpdateAsync(outageForAlert, autoSave: true, cancellationToken);
+        }
+
+        var configuration = new AlertChannelConfiguration(channels);
+        var channelDescriptors = _channelResolver.ResolveChannels(configuration);
+        if (channelDescriptors.Count == 0)
+        {
+            return dispatches;
+        }
+
+        var snapshot = new TargetSnapshot(
+            target.Id,
+            target.Name,
+            target.Type,
+            target.Endpoint,
+            target.CurrentStatus,
+            target.LastCheckedAt,
+            target.LastStatusChangeAt,
+            target.FirstDownAt,
+            target.LastUpAt,
+            target.Category);
+
+        var payload = new AlertPayload(
+            evaluation.EventType.Value,
+            timestamp,
+            result.ErrorSummary,
+            result.ResponseTimeMs,
+            CreateOutageSnapshot(outageForAlert));
+
+        dispatches.Add(new AlertDispatch(snapshot, payload, channelDescriptors));
+
+        return dispatches;
+    }
+
+    private async Task<bool> HasActiveMaintenanceAsync(Guid targetId, DateTime timestamp, CancellationToken cancellationToken)
+    {
+        return await _maintenanceRepository.AnyAsync(
+            window => window.StartUtc <= timestamp && window.EndUtc >= timestamp &&
+                      (window.TargetId == null || window.TargetId == targetId),
+            cancellationToken: cancellationToken);
+    }
+
+    private Dictionary<string, string[]> ResolveChannels(string? channelsJson)
+    {
+        var parsed = NotificationChannelResolver.ParseChannelsJson(channelsJson);
+        if (parsed.Count > 0)
+        {
+            return parsed;
+        }
+
+        return new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<string, string[]> CloneChannels(Dictionary<string, string[]>? source)
+    {
+        if (source == null || source.Count == 0)
+        {
+            return new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var clone = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in source)
+        {
+            if (kvp.Key.IsNullOrWhiteSpace())
+            {
+                continue;
+            }
+
+            var values = kvp.Value ?? Array.Empty<string>();
+            clone[kvp.Key] = values.Length == 0 ? Array.Empty<string>() : values.ToArray();
+        }
+
+        return clone;
+    }
+
+    private static OutageSnapshot? CreateOutageSnapshot(OutageWindow? outage)
+    {
+        if (outage == null)
+        {
+            return null;
+        }
+
+        return new OutageSnapshot(
+            outage.Id,
+            outage.StartedAt,
+            outage.EndedAt,
+            outage.FailureCount,
+            outage.TotalDurationSec);
+    }
+
+    private async Task DispatchAlertsAsync(IReadOnlyList<AlertDispatch> dispatches, CancellationToken cancellationToken)
+    {
+        var sent = 0;
+        var failed = 0;
+
+        foreach (var dispatch in dispatches)
+        {
+            foreach (var descriptor in dispatch.Channels)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    await descriptor.Channel.SendAsync(dispatch.Target, dispatch.Payload, cancellationToken);
+                    sent++;
+                    _logger.LogInformation(
+                        "Alert dispatched for target {TargetId} via {Channel} ({EventType}).",
+                        dispatch.Target.TargetId,
+                        descriptor.Name,
+                        dispatch.Payload.EventType);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    _logger.LogWarning(
+                        ex,
+                        "Alert dispatch failed for target {TargetId} via {Channel} ({EventType}).",
+                        dispatch.Target.TargetId,
+                        descriptor.Name,
+                        dispatch.Payload.EventType);
+                }
+            }
+        }
+
+        if (sent > 0 || failed > 0)
+        {
+            _logger.LogDebug("Alert dispatch summary: {Sent} succeeded, {Failed} failed.", sent, failed);
+        }
     }
 }

--- a/src/Monitoring.Application/Workers/MonitoringWorker.cs
+++ b/src/Monitoring.Application/Workers/MonitoringWorker.cs
@@ -41,7 +41,7 @@ public class MonitoringWorker : BackgroundService
     {
         using var timer = new PeriodicTimer(WorkerInterval);
 
-        while (!stoppingToken.IsCancellationRequested)
+        while (await timer.WaitForNextTickAsync(stoppingToken))
         {
             try
             {
@@ -54,18 +54,6 @@ public class MonitoringWorker : BackgroundService
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Monitoring worker cycle failed");
-            }
-
-            try
-            {
-                if (!await timer.WaitForNextTickAsync(stoppingToken))
-                {
-                    break;
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                break;
             }
         }
     }
@@ -104,7 +92,7 @@ public class MonitoringWorker : BackgroundService
             result = new HealthCheckResult(false, null, "Worker error", TriggerSource);
         }
 
-        await using var uow = _unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
 
         var recordedAt = _clock.Now;
         MonitoringTargetCheckProcessor.ApplyResult(target, result, recordedAt);

--- a/src/Monitoring.Application/Workers/MonitoringWorker.cs
+++ b/src/Monitoring.Application/Workers/MonitoringWorker.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Monitoring.HealthChecks;
 using Monitoring.Targets;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Guids;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
 
@@ -19,22 +20,31 @@ public class MonitoringWorker : BackgroundService
 
     private readonly ILogger<MonitoringWorker> _logger;
     private readonly IRepository<MonitoringTarget, Guid> _targetRepository;
+    private readonly IRepository<ServiceStatusHistory, Guid> _historyRepository;
+    private readonly IRepository<OutageWindow, Guid> _outageRepository;
     private readonly IHealthCheckProviderResolver _providerResolver;
     private readonly IClock _clock;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly IGuidGenerator _guidGenerator;
 
     public MonitoringWorker(
         ILogger<MonitoringWorker> logger,
         IRepository<MonitoringTarget, Guid> targetRepository,
+        IRepository<ServiceStatusHistory, Guid> historyRepository,
+        IRepository<OutageWindow, Guid> outageRepository,
         IHealthCheckProviderResolver providerResolver,
         IClock clock,
-        IUnitOfWorkManager unitOfWorkManager)
+        IUnitOfWorkManager unitOfWorkManager,
+        IGuidGenerator guidGenerator)
     {
         _logger = logger;
         _targetRepository = targetRepository;
+        _historyRepository = historyRepository;
+        _outageRepository = outageRepository;
         _providerResolver = providerResolver;
         _clock = clock;
         _unitOfWorkManager = unitOfWorkManager;
+        _guidGenerator = guidGenerator;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -95,7 +105,14 @@ public class MonitoringWorker : BackgroundService
         using var uow = _unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
 
         var recordedAt = _clock.Now;
-        MonitoringTargetCheckProcessor.ApplyResult(target, result, recordedAt);
+        await MonitoringTargetCheckProcessor.ApplyResultAsync(
+            target,
+            result,
+            recordedAt,
+            _historyRepository,
+            _outageRepository,
+            _guidGenerator,
+            cancellationToken);
 
         await _targetRepository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
         await uow.CompleteAsync();

--- a/src/Monitoring.Application/Workers/MonitoringWorker.cs
+++ b/src/Monitoring.Application/Workers/MonitoringWorker.cs
@@ -1,63 +1,85 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Monitoring.HealthChecks;
 using Monitoring.Targets;
-using Volo.Abp.BackgroundWorkers;
-using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
-using Volo.Abp.Threading;
 
 namespace Monitoring.Workers;
 
-public class MonitoringWorker : AsyncPeriodicBackgroundWorkerBase, ISingletonDependency
+public class MonitoringWorker : BackgroundService
 {
     private const string TriggerSource = "worker";
     private static readonly TimeSpan OverrideInterval = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan WorkerInterval = TimeSpan.FromMinutes(1);
 
+    private readonly ILogger<MonitoringWorker> _logger;
     private readonly IRepository<MonitoringTarget, Guid> _targetRepository;
     private readonly IHealthCheckProviderResolver _providerResolver;
     private readonly IClock _clock;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     public MonitoringWorker(
-        AbpAsyncTimer timer,
-        IServiceScopeFactory serviceScopeFactory,
+        ILogger<MonitoringWorker> logger,
         IRepository<MonitoringTarget, Guid> targetRepository,
         IHealthCheckProviderResolver providerResolver,
-        IClock clock)
-        : base(timer, serviceScopeFactory)
+        IClock clock,
+        IUnitOfWorkManager unitOfWorkManager)
     {
+        _logger = logger;
         _targetRepository = targetRepository;
         _providerResolver = providerResolver;
         _clock = clock;
-
-        Timer.Period = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
-        Timer.RunOnStart = true;
+        _unitOfWorkManager = unitOfWorkManager;
     }
 
-    protected override async Task DoWorkAsync(PeriodicBackgroundWorkerContext workerContext)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var cancellationToken = workerContext.CancellationToken;
+        using var timer = new PeriodicTimer(WorkerInterval);
 
-        var uowOptions = new AbpUnitOfWorkOptions
+        while (!stoppingToken.IsCancellationRequested)
         {
-            IsTransactional = false
-        };
+            try
+            {
+                await DoCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Monitoring worker cycle failed");
+            }
 
-        using var uow = UnitOfWorkManager.Begin(uowOptions, requiresNew: true);
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
 
+    private async Task DoCycleAsync(CancellationToken cancellationToken)
+    {
         var now = _clock.Now;
         var overrideThreshold = now - OverrideInterval;
 
         var targets = await _targetRepository.GetListAsync(
             target => target.IsActive &&
-                (target.NextDueAt <= now ||
-                 !target.LastCheckedAt.HasValue ||
-                 target.LastCheckedAt <= overrideThreshold),
+                      (target.NextDueAt <= now ||
+                       !target.LastCheckedAt.HasValue ||
+                       target.LastCheckedAt <= overrideThreshold),
             cancellationToken: cancellationToken);
 
         foreach (var target in targets)
@@ -66,8 +88,6 @@ public class MonitoringWorker : AsyncPeriodicBackgroundWorkerBase, ISingletonDep
 
             await HandleTargetAsync(target, cancellationToken);
         }
-
-        await uow.CompleteAsync();
     }
 
     private async Task HandleTargetAsync(MonitoringTarget target, CancellationToken cancellationToken)
@@ -80,14 +100,16 @@ public class MonitoringWorker : AsyncPeriodicBackgroundWorkerBase, ISingletonDep
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Monitoring worker failed for target {TargetId}", target.Id);
+            _logger.LogWarning(ex, "Monitoring worker failed for target {TargetId}", target.Id);
             result = new HealthCheckResult(false, null, "Worker error", TriggerSource);
         }
 
-        var recordedAt = _clock.Now;
+        await using var uow = _unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
 
+        var recordedAt = _clock.Now;
         MonitoringTargetCheckProcessor.ApplyResult(target, result, recordedAt);
 
         await _targetRepository.UpdateAsync(target, autoSave: true, cancellationToken: cancellationToken);
+        await uow.CompleteAsync();
     }
 }

--- a/src/Monitoring.Domain/HealthChecks/ApiCheckProvider.cs
+++ b/src/Monitoring.Domain/HealthChecks/ApiCheckProvider.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+
+namespace Monitoring.HealthChecks;
+
+public class ApiCheckProvider : IHealthCheckProvider
+{
+    private const int DefaultSuccessMin = 200;
+    private const int DefaultSuccessMax = 299;
+    private const int DefaultTimeoutSeconds = 5;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ISecretResolver _secretResolver;
+
+    public ApiCheckProvider(
+        IHttpClientFactory httpClientFactory,
+        ISecretResolver secretResolver)
+    {
+        _httpClientFactory = httpClientFactory;
+        _secretResolver = secretResolver;
+    }
+
+    public async Task<HealthCheckResult> CheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!Uri.TryCreate(target.Endpoint, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return new HealthCheckResult(false, null, "Invalid URL", triggerSource);
+        }
+
+        var settings = HealthCheckSettingsParser.ParseApi(target.SettingsJson);
+        var timeoutSeconds = target.TimeoutSeconds > 0 ? target.TimeoutSeconds : DefaultTimeoutSeconds;
+
+        var client = _httpClientFactory.CreateClient(nameof(ApiCheckProvider));
+        client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+        using var request = new HttpRequestMessage(
+            HttpHealthCheckHelper.ResolveMethod(settings.Method, HttpMethod.Get),
+            uri);
+
+        if (!string.IsNullOrWhiteSpace(settings.Body))
+        {
+            request.Content = new StringContent(settings.Body, Encoding.UTF8, "application/json");
+        }
+
+        ApplyHeaders(settings, request);
+
+        var authResult = ApplyAuthentication(settings, request, triggerSource);
+        if (authResult is not null)
+        {
+            return authResult;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var response = await client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            stopwatch.Stop();
+
+            var responseTimeMs = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+            var isSuccessStatus = HttpHealthCheckHelper.IsExpectedStatus(
+                response.StatusCode,
+                settings.ExpectedStatusCodes,
+                DefaultSuccessMin,
+                DefaultSuccessMax);
+
+            if (!isSuccessStatus)
+            {
+                return new HealthCheckResult(false, responseTimeMs, $"HTTP {(int)response.StatusCode}", triggerSource);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.ContainsKeyword))
+            {
+                var snippet = await HttpHealthCheckHelper.ReadContentSnippetAsync(response, cancellationToken);
+                if (snippet.IndexOf(settings.ContainsKeyword, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    return new HealthCheckResult(false, responseTimeMs, "Keyword not found", triggerSource);
+                }
+            }
+
+            return new HealthCheckResult(true, responseTimeMs, null, triggerSource);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, $"Timeout {timeoutSeconds}s", triggerSource);
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            var summary = ex.StatusCode.HasValue
+                ? $"HTTP {(int)ex.StatusCode.Value}"
+                : "Request failed";
+
+            return new HealthCheckResult(false, elapsed, summary, triggerSource);
+        }
+        catch (Exception)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, "Request failed", triggerSource);
+        }
+    }
+
+    private static void ApplyHeaders(ApiSettings settings, HttpRequestMessage request)
+    {
+        if (settings.Headers is null)
+        {
+            return;
+        }
+
+        foreach (var header in settings.Headers)
+        {
+            if (string.IsNullOrWhiteSpace(header.Key))
+            {
+                continue;
+            }
+
+            if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+    }
+
+    private HealthCheckResult? ApplyAuthentication(
+        ApiSettings settings,
+        HttpRequestMessage request,
+        string triggerSource)
+    {
+        if (settings.Auth is null || string.IsNullOrWhiteSpace(settings.Auth.Scheme))
+        {
+            return null;
+        }
+
+        var scheme = settings.Auth.Scheme.Trim();
+
+        if (string.Equals(scheme, "Bearer", StringComparison.OrdinalIgnoreCase))
+        {
+            var token = _secretResolver.Resolve(settings.Auth.TokenRef);
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return new HealthCheckResult(false, null, "Auth token missing", triggerSource);
+            }
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        else if (string.Equals(scheme, "Basic", StringComparison.OrdinalIgnoreCase))
+        {
+            var username = _secretResolver.Resolve(settings.Auth.UsernameRef);
+            var password = _secretResolver.Resolve(settings.Auth.PasswordRef);
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+            {
+                return new HealthCheckResult(false, null, "Auth credentials missing", triggerSource);
+            }
+
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        }
+
+        return null;
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/EndpointParser.cs
+++ b/src/Monitoring.Domain/HealthChecks/EndpointParser.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace Monitoring.HealthChecks;
 
-internal static class EndpointParser
+public static class EndpointParser
 {
     public static bool TryParseHostPort(string? value, out string host, out int port)
     {

--- a/src/Monitoring.Domain/HealthChecks/EndpointParser.cs
+++ b/src/Monitoring.Domain/HealthChecks/EndpointParser.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Globalization;
+
+namespace Monitoring.HealthChecks;
+
+internal static class EndpointParser
+{
+    public static bool TryParseHostPort(string? value, out string host, out int port)
+    {
+        host = string.Empty;
+        port = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var parts = value.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        var candidateHost = parts[0].Trim();
+        if (string.IsNullOrWhiteSpace(candidateHost))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var candidatePort))
+        {
+            return false;
+        }
+
+        if (candidatePort is < 1 or > 65535)
+        {
+            return false;
+        }
+
+        host = candidateHost;
+        port = candidatePort;
+        return true;
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/HealthCheckContracts.cs
+++ b/src/Monitoring.Domain/HealthChecks/HealthCheckContracts.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+
+namespace Monitoring.HealthChecks;
+
+public record HealthCheckResult(
+    bool IsSuccess,
+    int? ResponseTimeMs,
+    string? ErrorSummary,
+    string TriggerSource);
+
+public interface IHealthCheckProvider
+{
+    Task<HealthCheckResult> CheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IHealthCheckProviderResolver
+{
+    IHealthCheckProvider Resolve(ServiceType type);
+}

--- a/src/Monitoring.Domain/HealthChecks/HealthCheckProviderResolver.cs
+++ b/src/Monitoring.Domain/HealthChecks/HealthCheckProviderResolver.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Monitoring.Targets;
+
+namespace Monitoring.HealthChecks;
+
+public class HealthCheckProviderResolver : IHealthCheckProviderResolver
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public HealthCheckProviderResolver(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public IHealthCheckProvider Resolve(ServiceType type)
+    {
+        return type switch
+        {
+            ServiceType.Website => _serviceProvider.GetRequiredService<WebsiteCheckProvider>(),
+            ServiceType.Api => _serviceProvider.GetRequiredService<ApiCheckProvider>(),
+            ServiceType.Tcp => _serviceProvider.GetRequiredService<TcpCheckProvider>(),
+            ServiceType.Redis => _serviceProvider.GetRequiredService<RedisCheckProvider>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported service type")
+        };
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/HealthCheckSettings.cs
+++ b/src/Monitoring.Domain/HealthChecks/HealthCheckSettings.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+namespace Monitoring.HealthChecks;
+
+public sealed class WebsiteSettings
+{
+    public string? ContainsKeyword { get; set; }
+
+    public int[]? ExpectedStatusCodes { get; set; }
+
+    public string? Method { get; set; }
+}
+
+public sealed class ApiSettings
+{
+    public int[]? ExpectedStatusCodes { get; set; }
+
+    public string? ContainsKeyword { get; set; }
+
+    public Dictionary<string, string>? Headers { get; set; }
+
+    public ApiAuthOptions? Auth { get; set; }
+
+    public string? Method { get; set; }
+
+    public string? Body { get; set; }
+}
+
+public sealed class ApiAuthOptions
+{
+    public string? Scheme { get; set; }
+
+    public string? TokenRef { get; set; }
+
+    public string? UsernameRef { get; set; }
+
+    public string? PasswordRef { get; set; }
+}
+
+public sealed class TcpSettings
+{
+    public string? Host { get; set; }
+
+    public int? Port { get; set; }
+}
+
+public sealed class RedisSettings
+{
+    public string Mode { get; set; } = "standalone";
+
+    public string[] Endpoints { get; set; } = Array.Empty<string>();
+
+    public string[]? Sentinels { get; set; }
+
+    public string? SentinelMasterName { get; set; }
+
+    public string? UsernameRef { get; set; }
+
+    public string? PasswordRef { get; set; }
+
+    public bool UseTls { get; set; }
+
+    public bool AllowAdmin { get; set; }
+
+    public int Database { get; set; } = 0;
+
+    public string ExpectedRole { get; set; } = "any";
+
+    public bool PingCheck { get; set; } = true;
+
+    public int LatencyThresholdMs { get; set; } = 0;
+}

--- a/src/Monitoring.Domain/HealthChecks/HealthCheckSettingsParser.cs
+++ b/src/Monitoring.Domain/HealthChecks/HealthCheckSettingsParser.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.Json;
+
+namespace Monitoring.HealthChecks;
+
+internal static class HealthCheckSettingsParser
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static WebsiteSettings ParseWebsite(string? json)
+    {
+        return Deserialize(json, new WebsiteSettings());
+    }
+
+    public static ApiSettings ParseApi(string? json)
+    {
+        return Deserialize(json, new ApiSettings());
+    }
+
+    public static TcpSettings ParseTcp(string? json)
+    {
+        return Deserialize(json, new TcpSettings());
+    }
+
+    public static RedisSettings ParseRedis(string? json)
+    {
+        return Deserialize(json, new RedisSettings());
+    }
+
+    private static T Deserialize<T>(string? json, T fallback)
+        where T : class
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return fallback;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, SerializerOptions) ?? fallback;
+        }
+        catch (JsonException)
+        {
+            return fallback;
+        }
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/HttpHealthCheckHelper.cs
+++ b/src/Monitoring.Domain/HealthChecks/HttpHealthCheckHelper.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Buffers;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Monitoring.HealthChecks;
+
+internal static class HttpHealthCheckHelper
+{
+    private const int ContentSnippetLimit = 64 * 1024;
+
+    public static HttpMethod ResolveMethod(string? method, HttpMethod defaultMethod)
+    {
+        if (string.IsNullOrWhiteSpace(method))
+        {
+            return defaultMethod;
+        }
+
+        var upper = method.Trim().ToUpperInvariant();
+
+        return upper switch
+        {
+            "GET" => HttpMethod.Get,
+            "HEAD" => HttpMethod.Head,
+            "POST" => HttpMethod.Post,
+            "PUT" => HttpMethod.Put,
+            "DELETE" => HttpMethod.Delete,
+            "PATCH" => HttpMethod.Patch,
+            "OPTIONS" => HttpMethod.Options,
+            "TRACE" => HttpMethod.Trace,
+            _ => new HttpMethod(upper)
+        };
+    }
+
+    public static bool IsExpectedStatus(HttpStatusCode statusCode, int[]? expected, int defaultMin, int defaultMax)
+    {
+        var code = (int)statusCode;
+
+        if (expected is { Length: > 0 })
+        {
+            return expected.Contains(code);
+        }
+
+        return code >= defaultMin && code <= defaultMax;
+    }
+
+    public static async Task<string> ReadContentSnippetAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.Content is null)
+        {
+            return string.Empty;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var buffer = ArrayPool<byte>.Shared.Rent(ContentSnippetLimit);
+
+        try
+        {
+            var totalRead = 0;
+
+            while (totalRead < ContentSnippetLimit)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(totalRead, ContentSnippetLimit - totalRead), cancellationToken);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                totalRead += read;
+            }
+
+            if (totalRead == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.UTF8.GetString(buffer, 0, totalRead);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/ISecretResolver.cs
+++ b/src/Monitoring.Domain/HealthChecks/ISecretResolver.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Monitoring.HealthChecks;
+
+public interface ISecretResolver
+{
+    string? Resolve(string? reference);
+}
+
+public sealed class EnvironmentSecretResolver : ISecretResolver
+{
+    public string? Resolve(string? reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return null;
+        }
+
+        return Environment.GetEnvironmentVariable(reference);
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/RedisCheckProvider.cs
+++ b/src/Monitoring.Domain/HealthChecks/RedisCheckProvider.cs
@@ -1,0 +1,581 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+using StackExchange.Redis;
+
+namespace Monitoring.HealthChecks;
+
+public class RedisCheckProvider : IHealthCheckProvider
+{
+    private const int DefaultTimeoutSeconds = 5;
+
+    private readonly ISecretResolver _secretResolver;
+
+    public RedisCheckProvider(ISecretResolver secretResolver)
+    {
+        _secretResolver = secretResolver;
+    }
+
+    public async Task<HealthCheckResult> CheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var settings = HealthCheckSettingsParser.ParseRedis(target.SettingsJson);
+        var timeoutSeconds = target.TimeoutSeconds > 0 ? target.TimeoutSeconds : DefaultTimeoutSeconds;
+        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+        var username = ResolveSecret(settings.UsernameRef);
+        if (RequiresSecret(settings.UsernameRef) && string.IsNullOrEmpty(username))
+        {
+            return new HealthCheckResult(false, null, "Auth missing", triggerSource);
+        }
+
+        var password = ResolveSecret(settings.PasswordRef);
+        if (RequiresSecret(settings.PasswordRef) && string.IsNullOrEmpty(password))
+        {
+            return new HealthCheckResult(false, null, "Auth missing", triggerSource);
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        try
+        {
+            var (options, serverEndpoint, configurationError) = await CreateConfigurationOptionsAsync(
+                target,
+                settings,
+                timeout,
+                timeoutCts.Token);
+
+            if (options is null)
+            {
+                stopwatch.Stop();
+                var elapsed = stopwatch.ElapsedMilliseconds > 0
+                    ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                    : null;
+
+                return new HealthCheckResult(false, elapsed, configurationError ?? "Redis error", triggerSource);
+            }
+
+            ApplyCredentials(options, username, password);
+
+            using var connection = await ConnectionMultiplexer
+                .ConnectAsync(options)
+                .WaitAsync(timeoutCts.Token);
+
+            var database = connection.GetDatabase(settings.Database);
+
+            if (settings.PingCheck)
+            {
+                await database.PingAsync();
+            }
+
+            if (settings.AllowAdmin && !IsAnyRole(settings.ExpectedRole))
+            {
+                var roleMatches = await CheckRoleAsync(
+                    connection,
+                    serverEndpoint,
+                    settings.ExpectedRole,
+                    timeoutCts.Token);
+
+                if (!roleMatches)
+                {
+                    stopwatch.Stop();
+                    var roleElapsed = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+                    return new HealthCheckResult(false, roleElapsed, "Role mismatch", triggerSource);
+                }
+            }
+
+            stopwatch.Stop();
+            var elapsedMs = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+
+            if (settings.LatencyThresholdMs > 0 && elapsedMs > settings.LatencyThresholdMs)
+            {
+                return new HealthCheckResult(false, elapsedMs, $"High latency {elapsedMs}ms", triggerSource);
+            }
+
+            return new HealthCheckResult(true, elapsedMs, null, triggerSource);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, $"Timeout {timeoutSeconds}s", triggerSource);
+        }
+        catch (RedisTimeoutException)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, $"Timeout {timeoutSeconds}s", triggerSource);
+        }
+        catch (RedisConnectionException ex) when (TryMapSocketError(ex.InnerException, timeoutSeconds, out var summary))
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, summary, triggerSource);
+        }
+        catch (SocketException ex) when (TryMapSocketError(ex, timeoutSeconds, out var summary))
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, summary, triggerSource);
+        }
+        catch (RedisConnectionException)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, "Redis error", triggerSource);
+        }
+        catch (Exception)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, "Redis error", triggerSource);
+        }
+    }
+
+    private static bool RequiresSecret(string? reference)
+    {
+        return !string.IsNullOrWhiteSpace(reference);
+    }
+
+    private string? ResolveSecret(string? reference)
+    {
+        return _secretResolver.Resolve(reference);
+    }
+
+    private static void ApplyCredentials(
+        ConfigurationOptions options,
+        string? username,
+        string? password)
+    {
+        if (!string.IsNullOrEmpty(username))
+        {
+            options.User = username;
+        }
+
+        if (!string.IsNullOrEmpty(password))
+        {
+            options.Password = password;
+        }
+    }
+
+    private static bool TryMapSocketError(Exception? exception, int timeoutSeconds, out string summary)
+    {
+        summary = "Redis error";
+
+        if (exception is not SocketException socketException)
+        {
+            return false;
+        }
+
+        summary = socketException.SocketErrorCode switch
+        {
+            SocketError.ConnectionRefused => "Connect refused",
+            SocketError.HostNotFound or SocketError.NoData => "DNS error",
+            SocketError.TimedOut => $"Timeout {timeoutSeconds}s",
+            _ => "Redis error"
+        };
+
+        return true;
+    }
+
+    private async Task<(ConfigurationOptions? Options, EndPoint? ServerEndpoint, string? Error)> CreateConfigurationOptionsAsync(
+        MonitoringTarget target,
+        RedisSettings settings,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var mode = (settings.Mode ?? "standalone").Trim();
+
+        if (string.Equals(mode, "sentinel", StringComparison.OrdinalIgnoreCase))
+        {
+            return await CreateSentinelConfigurationAsync(settings, timeout, cancellationToken);
+        }
+
+        var endpoints = ResolveEndpoints(settings.Endpoints, target.Endpoint);
+        if (endpoints.Count == 0)
+        {
+            return (null, null, "Invalid host/port");
+        }
+
+        var options = CreateBaseOptions(settings, timeout);
+        foreach (var endpoint in endpoints)
+        {
+            options.EndPoints.Add(endpoint.Host, endpoint.Port);
+        }
+
+        return (options, options.EndPoints.FirstOrDefault(), null);
+    }
+
+    private async Task<(ConfigurationOptions? Options, EndPoint? ServerEndpoint, string? Error)> CreateSentinelConfigurationAsync(
+        RedisSettings settings,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        if (settings.Sentinels is null || settings.Sentinels.Length == 0)
+        {
+            return (null, null, "Sentinel master not found");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.SentinelMasterName))
+        {
+            return (null, null, "Sentinel master not found");
+        }
+
+        foreach (var sentinel in settings.Sentinels)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var master = await ResolveSentinelMasterAsync(
+                    sentinel,
+                    settings.SentinelMasterName,
+                    settings.UseTls,
+                    timeout,
+                    cancellationToken);
+
+                if (master is null)
+                {
+                    continue;
+                }
+
+                var (masterHost, masterPort) = master.Value;
+                var options = CreateBaseOptions(settings, timeout);
+                options.EndPoints.Add(masterHost, masterPort);
+
+                return (options, new DnsEndPoint(masterHost, masterPort), null);
+            }
+            catch (RedisConnectionException)
+            {
+                continue;
+            }
+            catch (RedisTimeoutException)
+            {
+                continue;
+            }
+            catch (RedisException)
+            {
+                continue;
+            }
+        }
+
+        return (null, null, "Sentinel master not found");
+    }
+
+    private async Task<(string Host, int Port)?> ResolveSentinelMasterAsync(
+        string sentinelEndpoint,
+        string masterName,
+        bool useTls,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseSentinelEndpoint(sentinelEndpoint, out var sentinelHost, out var sentinelPort))
+        {
+            return null;
+        }
+
+        var configuration = new ConfigurationOptions
+        {
+            AllowAdmin = true,
+            AbortOnConnectFail = false,
+            ConnectTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            SyncTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            ResponseTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            Ssl = useTls
+        };
+
+        configuration.EndPoints.Add(sentinelHost, sentinelPort);
+
+        using var connection = await ConnectionMultiplexer
+            .ConnectAsync(configuration)
+            .WaitAsync(cancellationToken);
+
+        var server = connection.GetServer(sentinelHost, sentinelPort);
+        var result = await server.ExecuteAsync(
+            "SENTINEL",
+            "get-master-addr-by-name",
+            masterName);
+
+        if (result.IsNull || result.Type != ResultType.MultiBulk)
+        {
+            return null;
+        }
+
+        var values = (RedisResult[])result;
+        if (values.Length < 2)
+        {
+            return null;
+        }
+
+        if (values[0].IsNull || values[1].IsNull)
+        {
+            return null;
+        }
+
+        var hostCandidate = values[0].ToString();
+        var portCandidate = values[1].ToString();
+
+        if (string.IsNullOrWhiteSpace(hostCandidate))
+        {
+            return null;
+        }
+
+        if (!int.TryParse(portCandidate, NumberStyles.Integer, CultureInfo.InvariantCulture, out var masterPort))
+        {
+            return null;
+        }
+
+        if (masterPort is < 1 or > 65535)
+        {
+            return null;
+        }
+
+        return (hostCandidate, masterPort);
+    }
+
+    private static bool TryParseSentinelEndpoint(string value, out string host, out int port)
+    {
+        host = string.Empty;
+        port = 0;
+
+        var parts = value.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPort))
+        {
+            return false;
+        }
+
+        if (parsedPort is < 1 or > 65535)
+        {
+            return false;
+        }
+
+        host = parts[0].Trim();
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        port = parsedPort;
+        return true;
+    }
+
+    private static ConfigurationOptions CreateBaseOptions(RedisSettings settings, TimeSpan timeout)
+    {
+        var options = new ConfigurationOptions
+        {
+            AbortOnConnectFail = false,
+            ConnectTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            SyncTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            ResponseTimeout = (int)Math.Max(1, timeout.TotalMilliseconds),
+            DefaultDatabase = settings.Database,
+            AllowAdmin = settings.AllowAdmin,
+            Ssl = settings.UseTls
+        };
+
+        if (string.Equals(settings.Mode, "cluster", StringComparison.OrdinalIgnoreCase))
+        {
+            options.TieBreaker = string.Empty;
+        }
+
+        return options;
+    }
+
+    private static List<(string Host, int Port)> ResolveEndpoints(string[]? configuredEndpoints, string? fallback)
+    {
+        var endpoints = new List<(string Host, int Port)>();
+
+        if (configuredEndpoints is not null)
+        {
+            foreach (var endpoint in configuredEndpoints)
+            {
+                if (EndpointParser.TryParseHostPort(endpoint, out var host, out var port))
+                {
+                    endpoints.Add((host, port));
+                }
+                else if (TryParseEndpoint(endpoint, out host, out port))
+                {
+                    endpoints.Add((host, port));
+                }
+            }
+        }
+
+        if (endpoints.Count > 0)
+        {
+            return endpoints;
+        }
+
+        if (!string.IsNullOrWhiteSpace(fallback))
+        {
+            foreach (var candidate in SplitEndpointList(fallback))
+            {
+                if (EndpointParser.TryParseHostPort(candidate, out var host, out var port))
+                {
+                    endpoints.Add((host, port));
+                }
+                else if (TryParseEndpoint(candidate, out host, out port))
+                {
+                    endpoints.Add((host, port));
+                }
+            }
+        }
+
+        return endpoints;
+    }
+
+    private static IEnumerable<string> SplitEndpointList(string value)
+    {
+        return value
+            .Split(new[] { ',', ';', '|', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(v => v.Trim())
+            .Where(v => !string.IsNullOrWhiteSpace(v));
+    }
+
+    private static bool TryParseEndpoint(string? value, out string host, out int port)
+    {
+        host = string.Empty;
+        port = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var candidate = value;
+        if (!value.Contains("://", StringComparison.Ordinal))
+        {
+            candidate = $"redis://{value}";
+        }
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri) &&
+            !string.IsNullOrWhiteSpace(uri.Host) &&
+            uri.Port > 0)
+        {
+            host = uri.Host;
+            port = uri.Port;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> CheckRoleAsync(
+        ConnectionMultiplexer connection,
+        EndPoint? preferredEndpoint,
+        string expectedRole,
+        CancellationToken cancellationToken)
+    {
+        var normalized = (expectedRole ?? string.Empty).Trim();
+        var endpoints = connection.GetEndPoints();
+        if (endpoints.Length == 0)
+        {
+            return false;
+        }
+
+        var ordered = preferredEndpoint is not null
+            ? new[] { preferredEndpoint }.Concat(endpoints.Where(e => !Equals(e, preferredEndpoint)))
+            : endpoints;
+
+        foreach (var endpoint in ordered)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var server = connection.GetServer(endpoint);
+            if (!server.IsConnected)
+            {
+                continue;
+            }
+
+            try
+            {
+                var role = await GetServerRoleAsync(server);
+                if (role is null)
+                {
+                    continue;
+                }
+
+                return MatchesRole(role, normalized);
+            }
+            catch (RedisServerException)
+            {
+                continue;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<string?> GetServerRoleAsync(IServer server)
+    {
+        var result = await server.ExecuteAsync("ROLE");
+        if (result.Type == ResultType.MultiBulk)
+        {
+            var items = (RedisResult[])result;
+            if (items.Length > 0)
+            {
+                return items[0].ToString();
+            }
+        }
+
+        return result.ToString();
+    }
+
+    private static bool MatchesRole(string role, string expectedRole)
+    {
+        if (string.Equals(expectedRole, "master", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Equals(role, "master", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (string.Equals(expectedRole, "replica", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Equals(role, "replica", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(role, "slave", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(role, "secondary", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return true;
+    }
+
+    private static bool IsAnyRole(string? expectedRole)
+    {
+        return string.IsNullOrWhiteSpace(expectedRole) ||
+               string.Equals(expectedRole, "any", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/TcpCheckProvider.cs
+++ b/src/Monitoring.Domain/HealthChecks/TcpCheckProvider.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+
+namespace Monitoring.HealthChecks;
+
+public class TcpCheckProvider : IHealthCheckProvider
+{
+    private const int DefaultTimeoutSeconds = 5;
+
+    public async Task<HealthCheckResult> CheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var settings = HealthCheckSettingsParser.ParseTcp(target.SettingsJson);
+        ResolveEndpoint(target.Endpoint, settings, out var host, out var port);
+
+        if (string.IsNullOrWhiteSpace(host) || port is null || port is < 1 or > 65535)
+        {
+            return new HealthCheckResult(false, null, "Invalid host/port", triggerSource);
+        }
+
+        var timeoutSeconds = target.TimeoutSeconds > 0 ? target.TimeoutSeconds : DefaultTimeoutSeconds;
+        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+        using var tcpClient = new TcpClient();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await tcpClient.ConnectAsync(host!, port.Value, timeoutCts.Token);
+
+            stopwatch.Stop();
+            var elapsed = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+
+            return new HealthCheckResult(true, elapsed, null, triggerSource);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, $"Timeout {timeoutSeconds}s", triggerSource);
+        }
+        catch (SocketException ex)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            var summary = ex.SocketErrorCode switch
+            {
+                SocketError.HostNotFound or SocketError.NoData => "Host not found",
+                SocketError.ConnectionRefused => "Connect refused",
+                SocketError.TimedOut => $"Timeout {timeoutSeconds}s",
+                _ => "TCP error"
+            };
+
+            return new HealthCheckResult(false, elapsed, summary, triggerSource);
+        }
+        catch (Exception)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, "TCP error", triggerSource);
+        }
+    }
+
+    private static void ResolveEndpoint(string? endpoint, TcpSettings settings, out string? host, out int? port)
+    {
+        host = null;
+        port = null;
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+        {
+            var trimmed = endpoint.Trim();
+
+            if (TryResolveHostPort(trimmed, out var parsedHost, out var parsedPort))
+            {
+                host = parsedHost;
+                port = parsedPort;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(host) && !string.IsNullOrWhiteSpace(settings.Host))
+        {
+            host = settings.Host.Trim();
+        }
+
+        if (port is null && settings.Port.HasValue)
+        {
+            port = settings.Port.Value;
+        }
+    }
+
+    private static bool TryResolveHostPort(string value, out string? host, out int? port)
+    {
+        host = null;
+        port = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (EndpointParser.TryParseHostPort(value, out var parsedHost, out var parsedPort))
+        {
+            host = parsedHost;
+            port = parsedPort;
+            return true;
+        }
+
+        var candidate = value;
+
+        if (!value.Contains("://", StringComparison.Ordinal))
+        {
+            candidate = $"tcp://{value}";
+        }
+
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) || string.IsNullOrWhiteSpace(uri.Host))
+        {
+            return false;
+        }
+
+        host = uri.Host;
+        port = uri.Port > 0 ? uri.Port : null;
+
+        return port.HasValue;
+    }
+}

--- a/src/Monitoring.Domain/HealthChecks/WebsiteCheckProvider.cs
+++ b/src/Monitoring.Domain/HealthChecks/WebsiteCheckProvider.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Monitoring.Targets;
+
+namespace Monitoring.HealthChecks;
+
+public class WebsiteCheckProvider : IHealthCheckProvider
+{
+    private const int DefaultSuccessMin = 200;
+    private const int DefaultSuccessMax = 399;
+    private const int DefaultTimeoutSeconds = 5;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public WebsiteCheckProvider(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<HealthCheckResult> CheckAsync(
+        MonitoringTarget target,
+        string triggerSource,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!Uri.TryCreate(target.Endpoint, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return new HealthCheckResult(false, null, "Invalid URL", triggerSource);
+        }
+
+        var settings = HealthCheckSettingsParser.ParseWebsite(target.SettingsJson);
+        var timeoutSeconds = target.TimeoutSeconds > 0 ? target.TimeoutSeconds : DefaultTimeoutSeconds;
+
+        var client = _httpClientFactory.CreateClient(nameof(WebsiteCheckProvider));
+        client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+        using var request = new HttpRequestMessage(
+            HttpHealthCheckHelper.ResolveMethod(settings.Method, HttpMethod.Get),
+            uri);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var response = await client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            stopwatch.Stop();
+
+            var responseTimeMs = (int)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+
+            var isSuccessStatus = HttpHealthCheckHelper.IsExpectedStatus(
+                response.StatusCode,
+                settings.ExpectedStatusCodes,
+                DefaultSuccessMin,
+                DefaultSuccessMax);
+
+            if (!isSuccessStatus)
+            {
+                return new HealthCheckResult(false, responseTimeMs, $"HTTP {(int)response.StatusCode}", triggerSource);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.ContainsKeyword))
+            {
+                var snippet = await HttpHealthCheckHelper.ReadContentSnippetAsync(response, cancellationToken);
+                if (snippet.IndexOf(settings.ContainsKeyword, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    return new HealthCheckResult(false, responseTimeMs, "Keyword not found", triggerSource);
+                }
+            }
+
+            return new HealthCheckResult(true, responseTimeMs, null, triggerSource);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, $"Timeout {timeoutSeconds}s", triggerSource);
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            var summary = ex.StatusCode.HasValue
+                ? $"HTTP {(int)ex.StatusCode.Value}"
+                : "Request failed";
+
+            return new HealthCheckResult(false, elapsed, summary, triggerSource);
+        }
+        catch (Exception)
+        {
+            stopwatch.Stop();
+            var elapsed = stopwatch.ElapsedMilliseconds > 0
+                ? (int?)Math.Round(stopwatch.Elapsed.TotalMilliseconds)
+                : null;
+
+            return new HealthCheckResult(false, elapsed, "Request failed", triggerSource);
+        }
+    }
+}

--- a/src/Monitoring.Domain/Monitoring.Domain.csproj
+++ b/src/Monitoring.Domain/Monitoring.Domain.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\\..\\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.Ddd.Domain" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp" Version="8.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+  </ItemGroup>
+
+</Project>

--- a/src/Monitoring.Domain/MonitoringConsts.cs
+++ b/src/Monitoring.Domain/MonitoringConsts.cs
@@ -1,0 +1,7 @@
+namespace Monitoring;
+
+public static class MonitoringConsts
+{
+    public const string DbTablePrefix = "Monitoring";
+    public const string DbSchema = null;
+}

--- a/src/Monitoring.Domain/MonitoringDomainModule.cs
+++ b/src/Monitoring.Domain/MonitoringDomainModule.cs
@@ -1,0 +1,11 @@
+using Volo.Abp.Domain;
+using Volo.Abp.Modularity;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(AbpDddDomainModule)
+    )]
+public class MonitoringDomainModule : AbpModule
+{
+}

--- a/src/Monitoring.Domain/Targets/AlertPolicy.cs
+++ b/src/Monitoring.Domain/Targets/AlertPolicy.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Text.Json;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace Monitoring.Targets;
+
+public class AlertPolicy : FullAuditedEntity<Guid>
+{
+    public Guid TargetId { get; private set; }
+
+    public bool Enabled { get; private set; }
+
+    public int NotifyAfterFailures { get; private set; }
+
+    public int RepeatMinutes { get; private set; }
+
+    public int RecoverQuietMinutes { get; private set; }
+
+    public string? ChannelsJson { get; private set; }
+
+    public bool SuppressDuringMaintenance { get; private set; }
+
+    protected AlertPolicy()
+    {
+    }
+
+    public AlertPolicy(
+        Guid id,
+        Guid targetId,
+        bool enabled,
+        int notifyAfterFailures,
+        int repeatMinutes,
+        int recoverQuietMinutes,
+        string? channelsJson,
+        bool suppressDuringMaintenance)
+        : base(id)
+    {
+        TargetId = targetId;
+        Update(enabled, notifyAfterFailures, repeatMinutes, recoverQuietMinutes, channelsJson, suppressDuringMaintenance);
+    }
+
+    public void Update(
+        bool enabled,
+        int notifyAfterFailures,
+        int repeatMinutes,
+        int recoverQuietMinutes,
+        string? channelsJson,
+        bool suppressDuringMaintenance)
+    {
+        Enabled = enabled;
+        SetNotifyAfterFailures(notifyAfterFailures);
+        SetRepeatMinutes(repeatMinutes);
+        SetRecoverQuietMinutes(recoverQuietMinutes);
+        SetChannelsJson(channelsJson);
+        SuppressDuringMaintenance = suppressDuringMaintenance;
+    }
+
+    private void SetNotifyAfterFailures(int value)
+    {
+        if (value < 1)
+        {
+            throw new BusinessException("Monitoring:InvalidNotifyAfterFailures")
+                .WithData("Minimum", 1);
+        }
+
+        NotifyAfterFailures = value;
+    }
+
+    private void SetRepeatMinutes(int value)
+    {
+        if (value < 1)
+        {
+            throw new BusinessException("Monitoring:InvalidRepeatMinutes")
+                .WithData("Minimum", 1);
+        }
+
+        RepeatMinutes = value;
+    }
+
+    private void SetRecoverQuietMinutes(int value)
+    {
+        if (value < 0)
+        {
+            throw new BusinessException("Monitoring:InvalidRecoverQuietMinutes")
+                .WithData("Minimum", 0);
+        }
+
+        RecoverQuietMinutes = value;
+    }
+
+    private void SetChannelsJson(string? value)
+    {
+        if (!value.IsNullOrWhiteSpace())
+        {
+            Check.Length(value, nameof(ChannelsJson), AlertPolicyConsts.ChannelsJsonMaxLength, 0);
+
+            try
+            {
+                JsonDocument.Parse(value);
+            }
+            catch (JsonException ex)
+            {
+                throw new BusinessException("Monitoring:InvalidAlertChannels", innerException: ex);
+            }
+        }
+
+        ChannelsJson = value;
+    }
+}

--- a/src/Monitoring.Domain/Targets/AlertPolicyConsts.cs
+++ b/src/Monitoring.Domain/Targets/AlertPolicyConsts.cs
@@ -1,0 +1,6 @@
+namespace Monitoring.Targets;
+
+public static class AlertPolicyConsts
+{
+    public const int ChannelsJsonMaxLength = 4000;
+}

--- a/src/Monitoring.Domain/Targets/MaintenanceWindow.cs
+++ b/src/Monitoring.Domain/Targets/MaintenanceWindow.cs
@@ -1,0 +1,68 @@
+using System;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace Monitoring.Targets;
+
+public class MaintenanceWindow : FullAuditedEntity<Guid>
+{
+    public Guid? TargetId { get; private set; }
+
+    public DateTime StartUtc { get; private set; }
+
+    public DateTime EndUtc { get; private set; }
+
+    public string? Reason { get; private set; }
+
+    protected MaintenanceWindow()
+    {
+    }
+
+    public MaintenanceWindow(Guid id, Guid? targetId, DateTime startUtc, DateTime endUtc, string? reason)
+        : base(id)
+    {
+        TargetId = targetId;
+        UpdateWindow(startUtc, endUtc, reason);
+    }
+
+    public void UpdateWindow(DateTime startUtc, DateTime endUtc, string? reason)
+    {
+        startUtc = NormalizeUtc(startUtc, nameof(StartUtc));
+        endUtc = NormalizeUtc(endUtc, nameof(EndUtc));
+
+        if (endUtc <= startUtc)
+        {
+            throw new BusinessException("Monitoring:MaintenanceWindowInvalidRange");
+        }
+
+        StartUtc = startUtc;
+        EndUtc = endUtc;
+        SetReason(reason);
+    }
+
+    public void SetReason(string? reason)
+    {
+        if (!reason.IsNullOrWhiteSpace())
+        {
+            Check.Length(reason, nameof(Reason), MaintenanceWindowConsts.ReasonMaxLength, 0);
+        }
+
+        Reason = reason;
+    }
+
+    private static DateTime NormalizeUtc(DateTime value, string field)
+    {
+        if (value.Kind == DateTimeKind.Unspecified)
+        {
+            return DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        }
+
+        if (value.Kind != DateTimeKind.Utc)
+        {
+            throw new BusinessException("Monitoring:MaintenanceWindowRequiresUtc")
+                .WithData("Field", field);
+        }
+
+        return value;
+    }
+}

--- a/src/Monitoring.Domain/Targets/MaintenanceWindowConsts.cs
+++ b/src/Monitoring.Domain/Targets/MaintenanceWindowConsts.cs
@@ -1,0 +1,6 @@
+namespace Monitoring.Targets;
+
+public static class MaintenanceWindowConsts
+{
+    public const int ReasonMaxLength = 256;
+}

--- a/src/Monitoring.Domain/Targets/MonitoringHistoryConsts.cs
+++ b/src/Monitoring.Domain/Targets/MonitoringHistoryConsts.cs
@@ -1,0 +1,22 @@
+using Volo.Abp;
+
+namespace Monitoring.Targets;
+
+public static class MonitoringHistoryConsts
+{
+    public const int TriggerSourceMaxLength = 32;
+    public const int ErrorSummaryMaxLength = 512;
+
+    public static void ValidateTriggerSource(string triggerSource)
+    {
+        Check.NotNullOrWhiteSpace(triggerSource, nameof(triggerSource), TriggerSourceMaxLength);
+    }
+
+    public static void ValidateErrorSummary(string? errorSummary)
+    {
+        if (!errorSummary.IsNullOrWhiteSpace())
+        {
+            Check.Length(errorSummary, nameof(errorSummary), ErrorSummaryMaxLength, 0);
+        }
+    }
+}

--- a/src/Monitoring.Domain/Targets/MonitoringHistoryConsts.cs
+++ b/src/Monitoring.Domain/Targets/MonitoringHistoryConsts.cs
@@ -14,7 +14,7 @@ public static class MonitoringHistoryConsts
 
     public static void ValidateErrorSummary(string? errorSummary)
     {
-        if (!errorSummary.IsNullOrWhiteSpace())
+        if (!string.IsNullOrWhiteSpace(errorSummary))
         {
             Check.Length(errorSummary, nameof(errorSummary), ErrorSummaryMaxLength, 0);
         }

--- a/src/Monitoring.Domain/Targets/MonitoringTarget.cs
+++ b/src/Monitoring.Domain/Targets/MonitoringTarget.cs
@@ -1,0 +1,196 @@
+using System;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace Monitoring.Targets;
+
+public class MonitoringTarget : FullAuditedAggregateRoot<Guid>
+{
+    public string Name { get; private set; } = null!;
+
+    public ServiceType Type { get; private set; }
+    public string Endpoint { get; private set; } = null!;
+
+    public string? SettingsJson { get; private set; }
+    public int CheckIntervalSeconds { get; private set; }
+    public int TimeoutSeconds { get; private set; }
+    public int MaxRetryAttempts { get; private set; }
+    public int RetryDelaySeconds { get; private set; }
+    public string? Category { get; private set; }
+    public bool IsActive { get; private set; }
+    public ServiceStatus CurrentStatus { get; private set; }
+    public DateTime? LastCheckedAt { get; private set; }
+    public DateTime? LastStatusChangeAt { get; private set; }
+    public DateTime NextDueAt { get; private set; }
+    public int ConsecutiveFailures { get; private set; }
+    public DateTime? FirstDownAt { get; private set; }
+    public DateTime? LastUpAt { get; private set; }
+    protected MonitoringTarget()
+    {
+    }
+
+    public MonitoringTarget(
+        Guid id,
+        string name,
+        ServiceType type,
+        string endpoint,
+        int checkIntervalSeconds,
+        int timeoutSeconds,
+        int maxRetryAttempts,
+        int retryDelaySeconds,
+        bool isActive,
+        ServiceStatus currentStatus,
+        DateTime nextDueAt,
+        string? settingsJson = null,
+        string? category = null)
+        : base(id)
+    {
+        SetName(name);
+        SetType(type);
+        SetEndpoint(endpoint);
+        UpdateCheckIntervalSeconds(checkIntervalSeconds);
+        UpdateTimeoutSeconds(timeoutSeconds);
+        UpdateRetrySettings(maxRetryAttempts, retryDelaySeconds);
+        SetSettingsJson(settingsJson);
+        SetCategory(category);
+        UpdateActivation(isActive);
+        SetCurrentStatus(currentStatus);
+        SetNextDueAt(nextDueAt);
+    }
+
+    public void SetName(string name)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(name), MonitoringTargetConsts.NameMaxLength);
+    }
+
+    public void SetType(ServiceType type)
+    {
+        if (!Enum.IsDefined(typeof(ServiceType), type))
+        {
+            throw new BusinessException("Monitoring:InvalidServiceType");
+        }
+
+        Type = type;
+    }
+
+    public void SetEndpoint(string endpoint)
+    {
+        Endpoint = Check.NotNullOrWhiteSpace(endpoint, nameof(endpoint), MonitoringTargetConsts.EndpointMaxLength);
+    }
+
+    public void SetSettingsJson(string? settingsJson)
+    {
+        if (!settingsJson.IsNullOrWhiteSpace())
+        {
+            Check.Length(settingsJson, nameof(settingsJson), MonitoringTargetConsts.SettingsJsonMaxLength, 0);
+        }
+
+        SettingsJson = settingsJson;
+    }
+
+    public void UpdateCheckIntervalSeconds(int seconds)
+    {
+        if (seconds <= 0)
+        {
+            throw new BusinessException("Monitoring:InvalidCheckInterval")
+                .WithData("Minimum", 1);
+        }
+
+        CheckIntervalSeconds = seconds;
+    }
+
+    public void UpdateTimeoutSeconds(int seconds)
+    {
+        if (seconds <= 0)
+        {
+            throw new BusinessException("Monitoring:InvalidTimeout")
+                .WithData("Minimum", 1);
+        }
+
+        TimeoutSeconds = seconds;
+    }
+
+    public void UpdateRetrySettings(int maxRetryAttempts, int retryDelaySeconds)
+    {
+        if (maxRetryAttempts < 0)
+        {
+            throw new BusinessException("Monitoring:InvalidRetryAttempts")
+                .WithData("Minimum", 0);
+        }
+
+        if (retryDelaySeconds < 0)
+        {
+            throw new BusinessException("Monitoring:InvalidRetryDelay")
+                .WithData("Minimum", 0);
+        }
+
+        MaxRetryAttempts = maxRetryAttempts;
+        RetryDelaySeconds = retryDelaySeconds;
+    }
+
+    public void SetCategory(string? category)
+    {
+        if (!category.IsNullOrWhiteSpace())
+        {
+            Check.Length(category, nameof(category), MonitoringTargetConsts.CategoryMaxLength, 0);
+        }
+
+        Category = category;
+    }
+
+    public void UpdateActivation(bool isActive)
+    {
+        IsActive = isActive;
+    }
+
+    public void SetCurrentStatus(ServiceStatus status)
+    {
+        if (!Enum.IsDefined(typeof(ServiceStatus), status))
+        {
+            throw new BusinessException("Monitoring:InvalidServiceStatus");
+        }
+
+        CurrentStatus = status;
+    }
+
+    public void SetLastCheckedAt(DateTime? lastCheckedAt)
+    {
+        LastCheckedAt = lastCheckedAt;
+    }
+
+    public void SetLastStatusChangeAt(DateTime? lastStatusChangeAt)
+    {
+        LastStatusChangeAt = lastStatusChangeAt;
+    }
+
+    public void SetNextDueAt(DateTime nextDueAt)
+    {
+        if (nextDueAt == default)
+        {
+            throw new BusinessException("Monitoring:InvalidNextDueAt");
+        }
+
+        NextDueAt = nextDueAt;
+    }
+
+    public void SetConsecutiveFailures(int consecutiveFailures)
+    {
+        if (consecutiveFailures < 0)
+        {
+            throw new BusinessException("Monitoring:InvalidConsecutiveFailures")
+                .WithData("Minimum", 0);
+        }
+
+        ConsecutiveFailures = consecutiveFailures;
+    }
+
+    public void SetFirstDownAt(DateTime? firstDownAt)
+    {
+        FirstDownAt = firstDownAt;
+    }
+
+    public void SetLastUpAt(DateTime? lastUpAt)
+    {
+        LastUpAt = lastUpAt;
+    }
+}

--- a/src/Monitoring.Domain/Targets/MonitoringTargetConsts.cs
+++ b/src/Monitoring.Domain/Targets/MonitoringTargetConsts.cs
@@ -1,0 +1,9 @@
+namespace Monitoring.Targets;
+
+public static class MonitoringTargetConsts
+{
+    public const int NameMaxLength = 200;
+    public const int EndpointMaxLength = 512;
+    public const int SettingsJsonMaxLength = 4000;
+    public const int CategoryMaxLength = 100;
+}

--- a/src/Monitoring.Domain/Targets/OutageWindow.cs
+++ b/src/Monitoring.Domain/Targets/OutageWindow.cs
@@ -10,6 +10,8 @@ public class OutageWindow : Entity<Guid>
     public DateTime? EndedAt { get; private set; }
     public int FailureCount { get; private set; }
     public int? TotalDurationSec { get; private set; }
+    public DateTime? LastAlertAt { get; private set; }
+    public int AlertsSent { get; private set; }
 
     private OutageWindow()
     {
@@ -45,5 +47,18 @@ public class OutageWindow : Entity<Guid>
         EndedAt = null;
         FailureCount = initialFailureCount < 1 ? 1 : initialFailureCount;
         TotalDurationSec = null;
+        ResetAlerts();
+    }
+
+    public void RecordAlert(DateTime timestamp)
+    {
+        LastAlertAt = timestamp;
+        AlertsSent++;
+    }
+
+    public void ResetAlerts()
+    {
+        LastAlertAt = null;
+        AlertsSent = 0;
     }
 }

--- a/src/Monitoring.Domain/Targets/OutageWindow.cs
+++ b/src/Monitoring.Domain/Targets/OutageWindow.cs
@@ -1,0 +1,49 @@
+using System;
+using Volo.Abp.Domain.Entities;
+
+namespace Monitoring.Targets;
+
+public class OutageWindow : Entity<Guid>
+{
+    public Guid TargetId { get; private set; }
+    public DateTime StartedAt { get; private set; }
+    public DateTime? EndedAt { get; private set; }
+    public int FailureCount { get; private set; }
+    public int? TotalDurationSec { get; private set; }
+
+    private OutageWindow()
+    {
+    }
+
+    public OutageWindow(Guid id, Guid targetId, DateTime startedAt, int failureCount)
+        : base(id)
+    {
+        TargetId = targetId;
+        MarkAsStarted(startedAt, failureCount);
+    }
+
+    public void IncrementFailure()
+    {
+        FailureCount++;
+    }
+
+    public void Close(DateTime endedAt)
+    {
+        if (EndedAt.HasValue)
+        {
+            return;
+        }
+
+        EndedAt = endedAt;
+        var duration = (int)Math.Max(0, (EndedAt.Value - StartedAt).TotalSeconds);
+        TotalDurationSec = duration;
+    }
+
+    public void MarkAsStarted(DateTime startedAt, int initialFailureCount)
+    {
+        StartedAt = startedAt;
+        EndedAt = null;
+        FailureCount = initialFailureCount < 1 ? 1 : initialFailureCount;
+        TotalDurationSec = null;
+    }
+}

--- a/src/Monitoring.Domain/Targets/ServiceStatus.cs
+++ b/src/Monitoring.Domain/Targets/ServiceStatus.cs
@@ -1,0 +1,8 @@
+namespace Monitoring.Targets;
+
+public enum ServiceStatus
+{
+    Online = 0,
+    Offline = 1,
+    Checking = 2
+}

--- a/src/Monitoring.Domain/Targets/ServiceStatusHistory.cs
+++ b/src/Monitoring.Domain/Targets/ServiceStatusHistory.cs
@@ -1,0 +1,51 @@
+using System;
+using Volo.Abp.Domain.Entities;
+
+namespace Monitoring.Targets;
+
+public class ServiceStatusHistory : Entity<Guid>
+{
+    public Guid TargetId { get; private set; }
+    public ServiceStatus FromStatus { get; private set; }
+    public ServiceStatus ToStatus { get; private set; }
+    public DateTime ChangedAt { get; private set; }
+    public string TriggerSource { get; private set; } = null!;
+    public int? ResponseTimeMs { get; private set; }
+    public string? ErrorSummary { get; private set; }
+
+    private ServiceStatusHistory()
+    {
+    }
+
+    public ServiceStatusHistory(
+        Guid id,
+        Guid targetId,
+        ServiceStatus fromStatus,
+        ServiceStatus toStatus,
+        DateTime changedAt,
+        string triggerSource,
+        int? responseTimeMs,
+        string? errorSummary)
+        : base(id)
+    {
+        TargetId = targetId;
+        FromStatus = fromStatus;
+        ToStatus = toStatus;
+        ChangedAt = changedAt;
+        SetTriggerSource(triggerSource);
+        SetResponseDetails(responseTimeMs, errorSummary);
+    }
+
+    public void SetTriggerSource(string triggerSource)
+    {
+        MonitoringHistoryConsts.ValidateTriggerSource(triggerSource);
+        TriggerSource = triggerSource;
+    }
+
+    public void SetResponseDetails(int? responseTimeMs, string? errorSummary)
+    {
+        ResponseTimeMs = responseTimeMs;
+        MonitoringHistoryConsts.ValidateErrorSummary(errorSummary);
+        ErrorSummary = errorSummary;
+    }
+}

--- a/src/Monitoring.Domain/Targets/ServiceType.cs
+++ b/src/Monitoring.Domain/Targets/ServiceType.cs
@@ -1,0 +1,9 @@
+namespace Monitoring.Targets;
+
+public enum ServiceType
+{
+    Website = 0,
+    Api = 1,
+    Tcp = 2,
+    Redis = 3
+}

--- a/src/Monitoring.HttpApi/Controllers/MonitoringDashboardController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringDashboardController.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Monitoring.Dashboard;
+using Monitoring.Targets;
+using Monitoring.Permissions;
+
+namespace Monitoring.Controllers;
+
+[Route("api/monitoring/dashboard")]
+[Authorize(MonitoringPermissions.Services.View)]
+public class MonitoringDashboardController : MonitoringController
+{
+    private readonly IDashboardAppService _dashboardAppService;
+
+    public MonitoringDashboardController(IDashboardAppService dashboardAppService)
+    {
+        _dashboardAppService = dashboardAppService;
+    }
+
+    [HttpGet("summary")]
+    public Task<DashboardSummaryDto> GetSummaryAsync([FromQuery] DateTime? from, [FromQuery] DateTime? to, [FromQuery] ServiceType? type)
+    {
+        return _dashboardAppService.GetSummaryAsync(from ?? default, to ?? default, type);
+    }
+
+    [HttpGet("uptime/{id}")]
+    public Task<List<UptimeBucketDto>> GetUptimeAsync(Guid id, [FromQuery] DateTime? from, [FromQuery] DateTime? to, [FromQuery] string bucket = "day")
+    {
+        return _dashboardAppService.GetUptimeSeriesAsync(id, from ?? default, to ?? default, bucket);
+    }
+
+    [HttpGet("incidents/{id}")]
+    public Task<List<DashboardIncidentDto>> GetIncidentsAsync(
+        Guid id,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] int skip = 0,
+        [FromQuery] int max = 100)
+    {
+        return _dashboardAppService.GetIncidentsAsync(id, from ?? default, to ?? default, skip, max);
+    }
+
+    [HttpGet("mttr-mtbf")]
+    public Task<MttrMtbfDto> GetReliabilityAsync([FromQuery] DateTime? from, [FromQuery] DateTime? to, [FromQuery] ServiceType? type)
+    {
+        return _dashboardAppService.GetReliabilityAsync(from ?? default, to ?? default, type);
+    }
+}

--- a/src/Monitoring.HttpApi/Controllers/MonitoringExportController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringExportController.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Monitoring.Dashboard;
+using Monitoring.Permissions;
+
+namespace Monitoring.Controllers;
+
+[Route("api/monitoring/export")]
+[Authorize(MonitoringPermissions.Services.View)]
+public class MonitoringExportController : MonitoringController
+{
+    private readonly IDashboardAppService _dashboardAppService;
+
+    public MonitoringExportController(IDashboardAppService dashboardAppService)
+    {
+        _dashboardAppService = dashboardAppService;
+    }
+
+    [HttpGet("uptime/{id}.csv")]
+    public async Task<FileContentResult> ExportUptimeAsync(Guid id, [FromQuery] DateTime? from, [FromQuery] DateTime? to, [FromQuery] string bucket = "day")
+    {
+        var series = await _dashboardAppService.GetUptimeSeriesAsync(id, from ?? default, to ?? default, bucket);
+        var builder = new StringBuilder();
+        builder.AppendLine("start,end,uptimePercentage");
+        foreach (var item in series)
+        {
+            builder.AppendLine(string.Join(',',
+                Escape(item.Start.ToString("O")),
+                Escape(item.End.ToString("O")),
+                Escape(item.UptimePercentage.ToString("0.##"))));
+        }
+
+        return File(Encoding.UTF8.GetBytes(builder.ToString()), "text/csv", $"uptime-{id}.csv");
+    }
+
+    [HttpGet("incidents/{id}.csv")]
+    public async Task<FileContentResult> ExportIncidentsAsync(Guid id, [FromQuery] DateTime? from, [FromQuery] DateTime? to)
+    {
+        var incidents = await _dashboardAppService.GetIncidentsAsync(id, from ?? default, to ?? default, 0, 10_000);
+        var builder = new StringBuilder();
+        builder.AppendLine("id,start,end,durationSeconds,failureCount");
+        foreach (var incident in incidents)
+        {
+            builder.AppendLine(string.Join(',',
+                Escape(incident.Id.ToString()),
+                Escape(incident.StartedAt.ToString("O")),
+                Escape(incident.EndedAt?.ToString("O") ?? string.Empty),
+                Escape((incident.TotalDurationSec ?? 0).ToString()),
+                Escape(incident.FailureCount.ToString())));
+        }
+
+        return File(Encoding.UTF8.GetBytes(builder.ToString()), "text/csv", $"incidents-{id}.csv");
+    }
+
+    private static string Escape(string value)
+    {
+        value ??= string.Empty;
+        if (value.Contains('"') || value.Contains(',') || value.Contains('\n'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+
+        return value;
+    }
+}

--- a/src/Monitoring.HttpApi/Controllers/MonitoringMaintenanceController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringMaintenanceController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Monitoring.Permissions;
+using Volo.Abp;
+
+namespace Monitoring.Targets;
+
+[RemoteService(Name = "Monitoring")]
+[Area("Monitoring")]
+[Authorize(MonitoringPermissions.Services.View)]
+[Route("api/monitoring/maintenance")]
+public class MonitoringMaintenanceController : MonitoringController
+{
+    private readonly IMonitoringTargetAppService _appService;
+
+    public MonitoringMaintenanceController(IMonitoringTargetAppService appService)
+    {
+        _appService = appService;
+    }
+
+    [HttpGet]
+    public virtual Task<List<MaintenanceWindowDto>> GetListAsync([FromQuery] Guid? targetId)
+    {
+        return _appService.GetMaintenanceAsync(targetId);
+    }
+
+    [HttpPost]
+    [Authorize(MonitoringPermissions.Services.Edit)]
+    public virtual Task<MaintenanceWindowDto> CreateAsync(CreateUpdateMaintenanceWindowDto input)
+    {
+        return _appService.CreateMaintenanceAsync(input);
+    }
+
+    [HttpDelete]
+    [Route("{id}")]
+    [Authorize(MonitoringPermissions.Services.Edit)]
+    public virtual Task DeleteAsync(Guid id)
+    {
+        return _appService.DeleteMaintenanceAsync(id);
+    }
+}

--- a/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
+using Volo.Abp.Application.Dtos;
+using Monitoring.Permissions;
+
+namespace Monitoring.Targets;
+
+[RemoteService(Name = "Monitoring")]
+[Area("Monitoring")]
+[Authorize(MonitoringPermissions.Services.View)]
+[Route("api/monitoring/targets")]
+public class MonitoringTargetController : MonitoringController
+{
+    private readonly IMonitoringTargetAppService _monitoringTargetAppService;
+
+    public MonitoringTargetController(IMonitoringTargetAppService monitoringTargetAppService)
+    {
+        _monitoringTargetAppService = monitoringTargetAppService;
+    }
+
+    [HttpGet]
+    public virtual Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(PagedAndSortedResultRequestDto input)
+    {
+        return _monitoringTargetAppService.GetListAsync(input);
+    }
+
+    [HttpGet]
+    [Route("{id}")]
+    public virtual Task<MonitoringTargetDto> GetAsync(Guid id)
+    {
+        return _monitoringTargetAppService.GetAsync(id);
+    }
+
+    [HttpPost]
+    [Authorize(MonitoringPermissions.Services.Create)]
+    public virtual Task<MonitoringTargetDto> CreateAsync(CreateUpdateMonitoringTargetDto input)
+    {
+        return _monitoringTargetAppService.CreateAsync(input);
+    }
+
+    [HttpPut]
+    [Route("{id}")]
+    [Authorize(MonitoringPermissions.Services.Edit)]
+    public virtual Task<MonitoringTargetDto> UpdateAsync(Guid id, CreateUpdateMonitoringTargetDto input)
+    {
+        return _monitoringTargetAppService.UpdateAsync(id, input);
+    }
+
+    [HttpDelete]
+    [Route("{id}")]
+    [Authorize(MonitoringPermissions.Services.Delete)]
+    public virtual Task DeleteAsync(Guid id)
+    {
+        return _monitoringTargetAppService.DeleteAsync(id);
+    }
+
+    [HttpPost]
+    [Route("{id}/trigger")]
+    [Authorize(MonitoringPermissions.Services.Run)]
+    public virtual Task TriggerAsync(Guid id)
+    {
+        return _monitoringTargetAppService.TriggerCheckAsync(id);
+    }
+
+    [HttpPost]
+    [Route("{id}/check")]
+    [Authorize(MonitoringPermissions.Services.Run)]
+    public virtual Task<HealthCheckResultDto> CheckNowAsync(Guid id)
+    {
+        return _monitoringTargetAppService.CheckNowAsync(id);
+    }
+
+    [HttpPost]
+    [Route("check-all")]
+    [Authorize(MonitoringPermissions.Services.Run)]
+    public virtual Task<List<HealthCheckResultDto>> CheckAllAsync()
+    {
+        return _monitoringTargetAppService.CheckAllAsync();
+    }
+}

--- a/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
@@ -23,6 +23,13 @@ public class MonitoringTargetController : MonitoringController
     }
 
     [HttpGet]
+    [Route("overview")]
+    public virtual Task<List<MonitoringTargetDto>> GetOverviewAsync([FromQuery] ServiceType? type)
+    {
+        return _monitoringTargetAppService.GetOverviewAsync(type);
+    }
+
+    [HttpGet]
     public virtual Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(PagedAndSortedResultRequestDto input)
     {
         return _monitoringTargetAppService.GetListAsync(input);

--- a/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
@@ -30,9 +30,12 @@ public class MonitoringTargetController : MonitoringController
     }
 
     [HttpGet]
-    public virtual Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(PagedAndSortedResultRequestDto input)
+    public virtual Task<PagedResultDto<MonitoringTargetDto>> GetListAsync(
+        PagedAndSortedResultRequestDto input,
+        [FromQuery] ServiceType? type,
+        [FromQuery] string? search)
     {
-        return _monitoringTargetAppService.GetListAsync(input);
+        return _monitoringTargetAppService.GetListAsync(input, type, search);
     }
 
     [HttpGet]

--- a/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
@@ -35,6 +35,20 @@ public class MonitoringTargetController : MonitoringController
         return _monitoringTargetAppService.GetAsync(id);
     }
 
+    [HttpGet]
+    [Route("{id}/outages")]
+    public virtual Task<List<OutageWindowDto>> GetRecentOutagesAsync(Guid id, [FromQuery] int count = 10)
+    {
+        return _monitoringTargetAppService.GetRecentOutagesAsync(id, count);
+    }
+
+    [HttpGet]
+    [Route("{id}/history")]
+    public virtual Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid id, [FromQuery] int count = 20)
+    {
+        return _monitoringTargetAppService.GetRecentStatusHistoryAsync(id, count);
+    }
+
     [HttpPost]
     [Authorize(MonitoringPermissions.Services.Create)]
     public virtual Task<MonitoringTargetDto> CreateAsync(CreateUpdateMonitoringTargetDto input)
@@ -80,5 +94,13 @@ public class MonitoringTargetController : MonitoringController
     public virtual Task<List<HealthCheckResultDto>> CheckAllAsync()
     {
         return _monitoringTargetAppService.CheckAllAsync();
+    }
+
+    [HttpPost]
+    [Route("~/api/monitoring/check-all")]
+    [Authorize(MonitoringPermissions.Services.Run)]
+    public virtual Task<int> CheckAllNowAsync()
+    {
+        return _monitoringTargetAppService.CheckAllNowAsync();
     }
 }

--- a/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
+++ b/src/Monitoring.HttpApi/Controllers/MonitoringTargetController.cs
@@ -53,6 +53,21 @@ public class MonitoringTargetController : MonitoringController
     }
 
     [HttpGet]
+    [Route("{id}/alert-policy")]
+    public virtual Task<AlertPolicyDto> GetAlertPolicyAsync(Guid id)
+    {
+        return _monitoringTargetAppService.GetAlertPolicyAsync(id);
+    }
+
+    [HttpPut]
+    [Route("{id}/alert-policy")]
+    [Authorize(MonitoringPermissions.Services.Edit)]
+    public virtual Task<AlertPolicyDto> UpsertAlertPolicyAsync(Guid id, AlertPolicyDto input)
+    {
+        return _monitoringTargetAppService.UpsertAlertPolicyAsync(id, input);
+    }
+
+    [HttpGet]
     [Route("{id}/history")]
     public virtual Task<List<ServiceStatusHistoryDto>> GetRecentStatusHistoryAsync(Guid id, [FromQuery] int count = 20)
     {

--- a/src/Monitoring.HttpApi/Monitoring.HttpApi.csproj
+++ b/src/Monitoring.HttpApi/Monitoring.HttpApi.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\\..\\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\Monitoring.Application.Contracts\\Monitoring.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.AspNetCore.Mvc" Version="8.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Monitoring.HttpApi/MonitoringController.cs
+++ b/src/Monitoring.HttpApi/MonitoringController.cs
@@ -1,0 +1,12 @@
+using Monitoring.Localization;
+using Volo.Abp.AspNetCore.Mvc;
+
+namespace Monitoring;
+
+public abstract class MonitoringController : AbpControllerBase
+{
+    protected MonitoringController()
+    {
+        LocalizationResource = typeof(MonitoringResource);
+    }
+}

--- a/src/Monitoring.HttpApi/MonitoringHttpApiModule.cs
+++ b/src/Monitoring.HttpApi/MonitoringHttpApiModule.cs
@@ -1,0 +1,12 @@
+using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.Modularity;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(MonitoringApplicationContractsModule),
+    typeof(AbpAspNetCoreMvcModule)
+    )]
+public class MonitoringHttpApiModule : AbpModule
+{
+}

--- a/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
+++ b/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Monitoring.Permissions;
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.UI.Navigation;
+
+namespace Monitoring.Menus;
+
+public class MonitoringMenuContributor : IMenuContributor
+{
+    public async Task ConfigureMenuAsync(MenuConfigurationContext context)
+    {
+        if (context.Menu.Name != StandardMenus.Main)
+        {
+            return;
+        }
+
+        var monitoringMenu = new ApplicationMenuItem(
+            MonitoringMenus.MonitoringTargets,
+            displayName: "Monitoring",
+            url: "/Monitoring/Targets",
+            icon: "fa fa-chart-line"
+        );
+
+        if (await context.IsGrantedAsync(MonitoringPermissions.Services.View))
+        {
+            context.Menu.AddItem(monitoringMenu);
+        }
+    }
+}

--- a/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
+++ b/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
@@ -14,16 +14,29 @@ public class MonitoringMenuContributor : IMenuContributor
             return;
         }
 
+        if (!await context.IsGrantedAsync(MonitoringPermissions.Services.View))
+        {
+            return;
+        }
+
         var monitoringMenu = new ApplicationMenuItem(
-            MonitoringMenus.MonitoringTargets,
+            MonitoringMenus.Monitoring,
             displayName: "Monitoring",
-            url: "/Monitoring/Targets",
             icon: "fa fa-chart-line"
         );
 
-        if (await context.IsGrantedAsync(MonitoringPermissions.Services.View))
-        {
-            context.Menu.AddItem(monitoringMenu);
-        }
+        monitoringMenu.AddItem(new ApplicationMenuItem(
+            MonitoringMenus.MonitoringDashboard,
+            displayName: "Dashboard",
+            url: "/Monitoring/Dashboard"
+        ));
+
+        monitoringMenu.AddItem(new ApplicationMenuItem(
+            MonitoringMenus.MonitoringTargets,
+            displayName: "Services",
+            url: "/Monitoring/Targets"
+        ));
+
+        context.Menu.AddItem(monitoringMenu);
     }
 }

--- a/src/Monitoring.Web/Menus/MonitoringMenus.cs
+++ b/src/Monitoring.Web/Menus/MonitoringMenus.cs
@@ -1,0 +1,7 @@
+namespace Monitoring.Menus;
+
+public static class MonitoringMenus
+{
+    private const string Prefix = "Monitoring";
+    public const string MonitoringTargets = Prefix + ".MonitoringTargets";
+}

--- a/src/Monitoring.Web/Menus/MonitoringMenus.cs
+++ b/src/Monitoring.Web/Menus/MonitoringMenus.cs
@@ -3,5 +3,7 @@ namespace Monitoring.Menus;
 public static class MonitoringMenus
 {
     private const string Prefix = "Monitoring";
-    public const string MonitoringTargets = Prefix + ".MonitoringTargets";
+    public const string Monitoring = Prefix + ".Root";
+    public const string MonitoringDashboard = Prefix + ".Dashboard";
+    public const string MonitoringTargets = Prefix + ".Targets";
 }

--- a/src/Monitoring.Web/Monitoring.Web.csproj
+++ b/src/Monitoring.Web/Monitoring.Web.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\\..\\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\Monitoring.HttpApi\\Monitoring.HttpApi.csproj" />
+    <ProjectReference Include="..\\Monitoring.Application\\Monitoring.Application.csproj" />
+    <ProjectReference Include="..\\Monitoring.Application.Contracts\\Monitoring.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.AutoMapper" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared" Version="8.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Monitoring.Web/MonitoringWebModule.cs
+++ b/src/Monitoring.Web/MonitoringWebModule.cs
@@ -1,0 +1,29 @@
+using Monitoring.Menus;
+using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
+using Volo.Abp.AutoMapper;
+using Volo.Abp.Modularity;
+using Volo.Abp.UI.Navigation;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(MonitoringHttpApiModule),
+    typeof(MonitoringApplicationModule),
+    typeof(AbpAutoMapperModule),
+    typeof(AbpAspNetCoreMvcUiThemeSharedModule)
+    )]
+public class MonitoringWebModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpNavigationOptions>(options =>
+        {
+            options.MenuContributors.Add(new MonitoringMenuContributor());
+        });
+
+        Configure<AbpAutoMapperOptions>(options =>
+        {
+            options.AddMaps<MonitoringWebModule>();
+        });
+    }
+}

--- a/src/Monitoring.Web/Pages/Monitoring/Dashboard/Index.cshtml
+++ b/src/Monitoring.Web/Pages/Monitoring/Dashboard/Index.cshtml
@@ -1,0 +1,175 @@
+@page
+@model Monitoring.Web.Pages.Monitoring.Dashboard.IndexModel
+@{
+    ViewData["Title"] = "Monitoring Dashboard";
+}
+
+<style>
+    .dashboard-card {
+        border-radius: .75rem;
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        padding: 1.5rem;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+        min-height: 8rem;
+    }
+
+    .dashboard-card h2 {
+        font-size: 2.25rem;
+        font-weight: 600;
+    }
+
+    .dashboard-toolbar .btn {
+        min-width: 8rem;
+    }
+
+    .chart-container {
+        position: relative;
+        min-height: 320px;
+    }
+</style>
+
+<div class="container-fluid" id="monitoring-dashboard" data-default-range="@Model.DefaultRangeDays" data-max-range="@Model.MaxRangeDays">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="mb-1">Monitoring Dashboard</h1>
+            <p class="text-muted mb-0">Insights across monitored targets, uptime trends, and incidents.</p>
+        </div>
+        <div class="d-flex flex-wrap gap-2 dashboard-toolbar">
+            <button id="dashboard-export-uptime" class="btn btn-outline-primary btn-sm" type="button">
+                <i class="fa fa-download me-1"></i>
+                Export uptime CSV
+            </button>
+            <button id="dashboard-export-incidents" class="btn btn-outline-secondary btn-sm" type="button">
+                <i class="fa fa-file-text-o me-1"></i>
+                Export incidents CSV
+            </button>
+        </div>
+    </div>
+
+    <div class="row g-3 align-items-end mb-4" id="dashboard-filters">
+        <div class="col-12 col-lg-3">
+            <label class="form-label" for="dashboard-range-start">From</label>
+            <input id="dashboard-range-start" class="form-control form-control-sm" type="datetime-local" aria-describedby="dashboard-range-help" />
+        </div>
+        <div class="col-12 col-lg-3">
+            <label class="form-label" for="dashboard-range-end">To</label>
+            <input id="dashboard-range-end" class="form-control form-control-sm" type="datetime-local" aria-describedby="dashboard-range-help" />
+        </div>
+        <div class="col-12 col-lg-2">
+            <label class="form-label" for="dashboard-type-filter">Service type</label>
+            <select id="dashboard-type-filter" class="form-select form-select-sm">
+                <option value="all">All</option>
+                <option value="Website">Website</option>
+                <option value="Api">API</option>
+                <option value="Tcp">TCP</option>
+                <option value="Redis">Redis</option>
+            </select>
+        </div>
+        <div class="col-12 col-lg-3">
+            <label class="form-label" for="dashboard-target-picker">Target</label>
+            <select id="dashboard-target-picker" class="form-select form-select-sm">
+                <option value="all">All targets</option>
+            </select>
+        </div>
+        <div class="col-12 col-lg-1 d-flex align-items-end">
+            <button id="dashboard-apply" class="btn btn-primary btn-sm w-100" type="button">Apply</button>
+        </div>
+        <div class="col-12">
+            <small id="dashboard-range-help" class="text-muted">Maximum range: @Model.MaxRangeDays days. Times shown in your local timezone.</small>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4" id="dashboard-summary">
+        <div class="col-12 col-lg-3">
+            <div class="dashboard-card h-100">
+                <p class="text-muted mb-1">Total targets</p>
+                <h2 id="dashboard-total-targets">0</h2>
+                <span class="text-muted small">Across all service types</span>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3">
+            <div class="dashboard-card h-100">
+                <p class="text-muted mb-1">Online</p>
+                <h2 id="dashboard-online">0</h2>
+                <span class="text-success small">Healthy checks</span>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3">
+            <div class="dashboard-card h-100">
+                <p class="text-muted mb-1">Offline</p>
+                <h2 id="dashboard-offline">0</h2>
+                <span class="text-danger small">Requires attention</span>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3">
+            <div class="dashboard-card h-100">
+                <p class="text-muted mb-1">Uptime</p>
+                <h2 id="dashboard-uptime">100%</h2>
+                <span class="text-muted small">Incidents <span id="dashboard-incidents-count">0</span> · Checking <span id="dashboard-checking">0</span></span>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-5">
+        <div class="col-12 col-xl-7">
+            <div class="dashboard-card h-100">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">Uptime trend</h5>
+                    <div>
+                        <button class="btn btn-sm btn-outline-secondary" type="button" data-range="24">24h</button>
+                        <button class="btn btn-sm btn-outline-secondary" type="button" data-range="7">7d</button>
+                        <button class="btn btn-sm btn-outline-secondary" type="button" data-range="30">30d</button>
+                    </div>
+                </div>
+                <div class="chart-container">
+                    <canvas id="dashboard-uptime-chart" role="img" aria-label="Uptime trend"></canvas>
+                </div>
+                <small class="text-muted d-block mt-2">Bucketed by hour or day depending on the selected range.</small>
+            </div>
+        </div>
+        <div class="col-12 col-xl-5">
+            <div class="dashboard-card h-100">
+                <h5 class="mb-3">Recent incidents</h5>
+                <div class="table-responsive" style="max-height: 320px;">
+                    <table class="table table-sm mb-0" id="dashboard-incidents-table">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Started</th>
+                                <th scope="col">Ended</th>
+                                <th scope="col">Duration</th>
+                                <th scope="col">Failures</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="text-muted">
+                                <td colspan="4">No incidents in range.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <small class="text-muted d-block mt-2">Showing up to 50 incidents for the selected target.</small>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-5">
+        <div class="col-12 col-xl-6">
+            <div class="dashboard-card h-100">
+                <h5 class="mb-3">Reliability (MTTR/MTBF)</h5>
+                <div id="dashboard-reliability" class="small text-muted">Loading…</div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-6">
+            <div class="dashboard-card h-100">
+                <h5 class="mb-3">Notes</h5>
+                <p class="text-muted mb-0 small">Data reflects UTC timestamps translated to your local browser timezone. Exported CSV files use ISO 8601 timestamps.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-1+NEnNh4tW7x1YgnSUZXoqBYwygJyI072QtdgQXl3k5iADG7n2AFDzy83H8XTurT" crossorigin="anonymous"></script>
+    <script src="~/js/monitoring.dashboard.js"></script>
+}

--- a/src/Monitoring.Web/Pages/Monitoring/Dashboard/Index.cshtml.cs
+++ b/src/Monitoring.Web/Pages/Monitoring/Dashboard/Index.cshtml.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using Monitoring.Options;
+using Monitoring.Permissions;
+using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+
+namespace Monitoring.Web.Pages.Monitoring.Dashboard;
+
+[Authorize(MonitoringPermissions.Services.View)]
+public class IndexModel : AbpPageModel
+{
+    public int DefaultRangeDays { get; }
+
+    public int MaxRangeDays { get; }
+
+    public IndexModel(IOptions<MonitoringOptions> options)
+    {
+        var dashboard = options.Value.Dashboard;
+        DefaultRangeDays = dashboard.DefaultRangeDays <= 0 ? 7 : dashboard.DefaultRangeDays;
+        MaxRangeDays = dashboard.MaxRangeDays <= 0 ? DefaultRangeDays : dashboard.MaxRangeDays;
+        if (MaxRangeDays < DefaultRangeDays)
+        {
+            MaxRangeDays = DefaultRangeDays;
+        }
+    }
+}

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
@@ -45,6 +45,14 @@
             <p class="text-muted mb-0">Track and manage the health of your monitored targets.</p>
         </div>
         <div class="d-flex flex-wrap gap-2">
+            @if (Model.CanEdit)
+            {
+                <button id="monitoring-maintenance-button" class="btn btn-outline-secondary btn-sm" type="button">
+                    <i class="fa fa-wrench me-1"></i>
+                    Maintenance
+                </button>
+            }
+
             @if (Model.CanCreate)
             {
                 <button id="monitoring-new-button" class="btn btn-success btn-sm" type="button">
@@ -210,6 +218,121 @@
     </div>
 </div>
 
+<div class="modal fade" id="monitoring-alert-policy-modal" tabindex="-1" aria-hidden="true" aria-labelledby="monitoring-alert-policy-modal-title">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="monitoring-alert-policy-form">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="monitoring-alert-policy-modal-title">Alert policy</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="monitoring-alert-policy-errors" class="alert alert-danger d-none" role="alert"></div>
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" type="checkbox" role="switch" id="monitoring-alert-policy-enabled" name="enabled">
+                        <label class="form-check-label" for="monitoring-alert-policy-enabled">Alerts enabled</label>
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                            <label class="form-label" for="monitoring-alert-policy-notify-after">Notify after failures</label>
+                            <input type="number" class="form-control" id="monitoring-alert-policy-notify-after" name="notifyAfterFailures" min="1" required>
+                        </div>
+                        <div class="col-12 col-md-6">
+                            <label class="form-label" for="monitoring-alert-policy-repeat">Repeat every (minutes)</label>
+                            <input type="number" class="form-control" id="monitoring-alert-policy-repeat" name="repeatMinutes" min="1" required>
+                        </div>
+                        <div class="col-12 col-md-6">
+                            <label class="form-label" for="monitoring-alert-policy-recover">Recovery quiet period (minutes)</label>
+                            <input type="number" class="form-control" id="monitoring-alert-policy-recover" name="recoverQuietMinutes" min="0" required>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="monitoring-alert-policy-channels">Channels (JSON)</label>
+                            <textarea class="form-control font-monospace" id="monitoring-alert-policy-channels" name="channelsJson" rows="5" spellcheck="false" placeholder="{ }"></textarea>
+                            <div class="form-text">Example: { "email": ["ops@example.com"], "webhook": ["https://hooks.example"], "telegram": ["-100123"] }</div>
+                        </div>
+                        <div class="col-12">
+                            <div class="form-check mt-2">
+                                <input class="form-check-input" type="checkbox" id="monitoring-alert-policy-suppress" name="suppressDuringMaintenance">
+                                <label class="form-check-label" for="monitoring-alert-policy-suppress">Suppress during maintenance windows</label>
+                            </div>
+                        </div>
+                    </div>
+                    <input type="hidden" id="monitoring-alert-policy-target-id" name="targetId">
+                    <div class="mt-3 small text-muted" id="monitoring-alert-policy-inheritance"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        <span class="spinner-border spinner-border-sm align-middle me-2 d-none" role="status" aria-hidden="true"></span>
+                        <span data-role="submit-label">Save</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="monitoring-maintenance-modal" tabindex="-1" aria-hidden="true" aria-labelledby="monitoring-maintenance-modal-title">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="monitoring-maintenance-modal-title">Maintenance windows</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div id="monitoring-maintenance-errors" class="alert alert-danger d-none" role="alert"></div>
+                <form id="monitoring-maintenance-form" class="border rounded p-3 mb-4">
+                    <h6 class="mb-3">Schedule maintenance</h6>
+                    <div class="row g-3 align-items-end">
+                        <div class="col-12 col-md-4">
+                            <label class="form-label" for="monitoring-maintenance-target">Target (optional)</label>
+                            <select id="monitoring-maintenance-target" name="targetId" class="form-select">
+                                <option value="">All services (global)</option>
+                            </select>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <label class="form-label" for="monitoring-maintenance-start">Start (UTC)</label>
+                            <input type="datetime-local" class="form-control" id="monitoring-maintenance-start" name="startUtc" required>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <label class="form-label" for="monitoring-maintenance-end">End (UTC)</label>
+                            <input type="datetime-local" class="form-control" id="monitoring-maintenance-end" name="endUtc" required>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="monitoring-maintenance-reason">Reason</label>
+                            <input type="text" class="form-control" id="monitoring-maintenance-reason" name="reason" maxlength="256" placeholder="Optional">
+                        </div>
+                    </div>
+                    <div class="mt-3 text-end">
+                        <button type="submit" class="btn btn-primary btn-sm">
+                            <span class="spinner-border spinner-border-sm align-middle me-2 d-none" role="status" aria-hidden="true"></span>
+                            Schedule maintenance
+                        </button>
+                    </div>
+                </form>
+
+                <div class="table-responsive">
+                    <table class="table table-sm" id="monitoring-maintenance-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Start (UTC)</th>
+                                <th scope="col">End (UTC)</th>
+                                <th scope="col">Target</th>
+                                <th scope="col">Reason</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @section scripts {
     <abp-script src="~/js/monitoring.targets.js"></abp-script>
     <script>
@@ -236,6 +359,18 @@
                     manageForm: document.getElementById('monitoring-manage-form'),
                     manageErrors: document.getElementById('monitoring-manage-errors'),
                     manageSubmitButton: document.querySelector('#monitoring-manage-form button[type="submit"]'),
+                    alertPolicyModal: document.getElementById('monitoring-alert-policy-modal'),
+                    alertPolicyForm: document.getElementById('monitoring-alert-policy-form'),
+                    alertPolicyErrors: document.getElementById('monitoring-alert-policy-errors'),
+                    alertPolicySubmit: document.querySelector('#monitoring-alert-policy-form button[type="submit"]'),
+                    alertPolicyInheritance: document.getElementById('monitoring-alert-policy-inheritance'),
+                    maintenanceButton: document.getElementById('monitoring-maintenance-button'),
+                    maintenanceModal: document.getElementById('monitoring-maintenance-modal'),
+                    maintenanceForm: document.getElementById('monitoring-maintenance-form'),
+                    maintenanceErrors: document.getElementById('monitoring-maintenance-errors'),
+                    maintenanceSubmit: document.querySelector('#monitoring-maintenance-form button[type="submit"]'),
+                    maintenanceTableBody: document.querySelector('#monitoring-maintenance-table tbody'),
+                    maintenanceTargetSelect: document.getElementById('monitoring-maintenance-target'),
                     pageInfo: document.getElementById('monitoring-page-info'),
                     prevButton: document.getElementById('monitoring-prev-page'),
                     nextButton: document.getElementById('monitoring-next-page')

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
@@ -42,22 +42,19 @@
     <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
         <div>
             <h1 class="mb-1">Monitoring Services</h1>
-            <p class="text-muted mb-0">Track the live status of your monitored targets.</p>
+            <p class="text-muted mb-0">Track and manage the health of your monitored targets.</p>
         </div>
-        <div class="d-flex flex-column flex-md-row align-items-md-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <label class="fw-semibold" for="monitoring-type-filter">Service type</label>
-                <select id="monitoring-type-filter" class="form-select form-select-sm w-auto">
-                    <option value="all">All</option>
-                    <option value="Website">Website</option>
-                    <option value="Api">API</option>
-                    <option value="Tcp">TCP</option>
-                    <option value="Redis">Redis</option>
-                </select>
-            </div>
+        <div class="d-flex flex-wrap gap-2">
+            @if (Model.CanCreate)
+            {
+                <button id="monitoring-new-button" class="btn btn-success btn-sm" type="button">
+                    <i class="fa fa-plus me-1"></i>
+                    New Service
+                </button>
+            }
             @if (Model.CanRun)
             {
-                <button id="monitoring-check-all-button" class="btn btn-primary btn-sm">
+                <button id="monitoring-check-all-button" class="btn btn-primary btn-sm" type="button">
                     <i class="fa fa-play-circle me-1"></i>
                     Check All Now
                 </button>
@@ -65,7 +62,48 @@
         </div>
     </div>
 
-    <div id="monitoring-targets-container" class="row g-4"></div>
+    <div class="row g-3 align-items-end mb-4" id="monitoring-filters">
+        <div class="col-12 col-md-4 col-xl-3">
+            <label class="form-label" for="monitoring-type-filter">Service type</label>
+            <select id="monitoring-type-filter" class="form-select form-select-sm">
+                <option value="all">All</option>
+                <option value="Website">Website</option>
+                <option value="Api">API</option>
+                <option value="Tcp">TCP</option>
+                <option value="Redis">Redis</option>
+            </select>
+        </div>
+        <div class="col-12 col-md-4 col-xl-3">
+            <label class="form-label" for="monitoring-search">Search</label>
+            <input type="search" id="monitoring-search" class="form-control form-control-sm" placeholder="Search by name or endpoint" aria-label="Search services" />
+        </div>
+        <div class="col-12 col-md-4 col-xl-3">
+            <label class="form-label" for="monitoring-sort">Sort by</label>
+            <select id="monitoring-sort" class="form-select form-select-sm">
+                <option value="Name">Name (A–Z)</option>
+                <option value="Name desc">Name (Z–A)</option>
+                <option value="LastCheckedAt desc">Last checked (newest)</option>
+                <option value="NextDueAt">Next check (soonest)</option>
+            </select>
+        </div>
+        <div class="col-12 col-xl-3 text-xl-end">
+            <small class="text-muted">Filters are saved in the address bar for easy sharing.</small>
+        </div>
+    </div>
+
+    <div id="monitoring-targets-container" class="row g-4" aria-live="polite"></div>
+
+    <nav class="d-flex justify-content-between align-items-center mt-4" aria-label="Monitoring pagination">
+        <button id="monitoring-prev-page" class="btn btn-outline-secondary btn-sm" type="button">
+            <i class="fa fa-chevron-left me-1"></i>
+            Previous
+        </button>
+        <div class="text-muted small" id="monitoring-page-info">&nbsp;</div>
+        <button id="monitoring-next-page" class="btn btn-outline-secondary btn-sm" type="button">
+            Next
+            <i class="fa fa-chevron-right ms-1"></i>
+        </button>
+    </nav>
 </div>
 
 <div class="modal fade" id="monitoring-outages-modal" tabindex="-1" aria-hidden="true">
@@ -98,55 +136,74 @@
     </div>
 </div>
 
-<div class="modal fade" id="monitoring-edit-modal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="monitoring-manage-modal" tabindex="-1" aria-hidden="true" aria-labelledby="monitoring-manage-modal-title">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="monitoring-edit-form">
+            <form id="monitoring-manage-form">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="monitoring-edit-modal-title">Edit service</h5>
+                    <h5 class="modal-title" id="monitoring-manage-modal-title">New service</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <div id="monitoring-manage-errors" class="alert alert-danger d-none" role="alert"></div>
                     <div class="row g-3">
+                        <div class="col-12 col-lg-6">
+                            <label class="form-label" for="monitoring-manage-name">Name</label>
+                            <input type="text" class="form-control" id="monitoring-manage-name" name="name" required minlength="2" maxlength="128" />
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <label class="form-label" for="monitoring-manage-type">Type</label>
+            <select id="monitoring-manage-type" name="type" class="form-select" required>
+                <option value="0">Website</option>
+                <option value="1">API</option>
+                <option value="2">TCP</option>
+                <option value="3">Redis</option>
+            </select>
+        </div>
                         <div class="col-12">
-                            <label class="form-label" for="monitoring-edit-name">Name</label>
-                            <input type="text" class="form-control" id="monitoring-edit-name" name="name" required maxlength="200">
+                            <label class="form-label" for="monitoring-manage-endpoint">Endpoint</label>
+                            <input type="text" class="form-control" id="monitoring-manage-endpoint" name="endpoint" required maxlength="512" />
+                            <div class="form-text">For TCP/Redis targets, use host:port unless overridden in settings.</div>
                         </div>
                         <div class="col-12">
-                            <label class="form-label" for="monitoring-edit-endpoint">Endpoint</label>
-                            <input type="text" class="form-control" id="monitoring-edit-endpoint" name="endpoint" required maxlength="512">
+                            <label class="form-label" for="monitoring-manage-settings">Settings (JSON)</label>
+                            <textarea class="form-control font-monospace" id="monitoring-manage-settings" name="settingsJson" rows="5" spellcheck="false" placeholder="{ }"></textarea>
+                            <div class="form-text">Leave blank to use defaults. The JSON is validated before saving.</div>
                         </div>
-                        <div class="col-md-6">
-                            <label class="form-label" for="monitoring-edit-interval">Check interval (seconds)</label>
-                            <input type="number" class="form-control" id="monitoring-edit-interval" name="checkIntervalSeconds" min="1" required>
+                        <div class="col-12 col-md-6 col-xl-3">
+                            <label class="form-label" for="monitoring-manage-interval">Check interval (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-manage-interval" name="checkIntervalSeconds" min="10" required />
                         </div>
-                        <div class="col-md-6">
-                            <label class="form-label" for="monitoring-edit-timeout">Timeout (seconds)</label>
-                            <input type="number" class="form-control" id="monitoring-edit-timeout" name="timeoutSeconds" min="1" required>
+                        <div class="col-12 col-md-6 col-xl-3">
+                            <label class="form-label" for="monitoring-manage-timeout">Timeout (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-manage-timeout" name="timeoutSeconds" min="1" required />
                         </div>
-                        <div class="col-md-6">
-                            <label class="form-label" for="monitoring-edit-retries">Max retries</label>
-                            <input type="number" class="form-control" id="monitoring-edit-retries" name="maxRetryAttempts" min="0" required>
+                        <div class="col-12 col-md-6 col-xl-3">
+                            <label class="form-label" for="monitoring-manage-retries">Max retries</label>
+                            <input type="number" class="form-control" id="monitoring-manage-retries" name="maxRetryAttempts" min="0" required />
                         </div>
-                        <div class="col-md-6">
-                            <label class="form-label" for="monitoring-edit-retry-delay">Retry delay (seconds)</label>
-                            <input type="number" class="form-control" id="monitoring-edit-retry-delay" name="retryDelaySeconds" min="0" required>
+                        <div class="col-12 col-md-6 col-xl-3">
+                            <label class="form-label" for="monitoring-manage-retry-delay">Retry delay (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-manage-retry-delay" name="retryDelaySeconds" min="1" required />
                         </div>
-                        <div class="col-md-6">
-                            <label class="form-label" for="monitoring-edit-category">Category</label>
-                            <input type="text" class="form-control" id="monitoring-edit-category" name="category" maxlength="100">
+                        <div class="col-12 col-md-6 col-xl-4">
+                            <label class="form-label" for="monitoring-manage-category">Category</label>
+                            <input type="text" class="form-control" id="monitoring-manage-category" name="category" maxlength="100" />
                         </div>
-                        <div class="col-md-6 d-flex align-items-center">
+                        <div class="col-12 col-md-6 col-xl-4 d-flex align-items-center">
                             <div class="form-check mt-4">
-                                <input class="form-check-input" type="checkbox" id="monitoring-edit-is-active" name="isActive">
-                                <label class="form-check-label" for="monitoring-edit-is-active">Active</label>
+                                <input class="form-check-input" type="checkbox" id="monitoring-manage-is-active" name="isActive" checked />
+                                <label class="form-check-label" for="monitoring-manage-is-active">Active</label>
                             </div>
                         </div>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Save changes</button>
+                    <button type="submit" class="btn btn-primary">
+                        <span class="spinner-border spinner-border-sm align-middle me-2 d-none" role="status" aria-hidden="true"></span>
+                        <span data-role="submit-label">Save</span>
+                    </button>
                 </div>
             </form>
         </div>
@@ -159,7 +216,8 @@
         window.monitoringPermissions = {
             canRun: @Model.CanRun.ToString().ToLowerInvariant(),
             canEdit: @Model.CanEdit.ToString().ToLowerInvariant(),
-            canDelete: @Model.CanDelete.ToString().ToLowerInvariant()
+            canDelete: @Model.CanDelete.ToString().ToLowerInvariant(),
+            canCreate: @Model.CanCreate.ToString().ToLowerInvariant()
         };
 
         document.addEventListener('DOMContentLoaded', function () {
@@ -167,13 +225,20 @@
                 window.monitoringTargets.init({
                     container: document.getElementById('monitoring-targets-container'),
                     filterSelect: document.getElementById('monitoring-type-filter'),
+                    searchInput: document.getElementById('monitoring-search'),
+                    sortSelect: document.getElementById('monitoring-sort'),
                     checkAllButton: document.getElementById('monitoring-check-all-button'),
+                    newButton: document.getElementById('monitoring-new-button'),
                     outagesModal: document.getElementById('monitoring-outages-modal'),
                     outagesModalTitle: document.getElementById('monitoring-outages-modal-title'),
                     outagesTableBody: document.querySelector('#monitoring-outages-table tbody'),
-                    editModal: document.getElementById('monitoring-edit-modal'),
-                    editModalTitle: document.getElementById('monitoring-edit-modal-title'),
-                    editForm: document.getElementById('monitoring-edit-form')
+                    manageModal: document.getElementById('monitoring-manage-modal'),
+                    manageForm: document.getElementById('monitoring-manage-form'),
+                    manageErrors: document.getElementById('monitoring-manage-errors'),
+                    manageSubmitButton: document.querySelector('#monitoring-manage-form button[type="submit"]'),
+                    pageInfo: document.getElementById('monitoring-page-info'),
+                    prevButton: document.getElementById('monitoring-prev-page'),
+                    nextButton: document.getElementById('monitoring-next-page')
                 });
             }
         });

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
@@ -1,0 +1,181 @@
+@page
+@model Monitoring.Web.Pages.Monitoring.Targets.IndexModel
+@{
+    ViewData["Title"] = "Monitoring Services";
+}
+
+<style>
+    .status-border {
+        border: 2px solid var(--card-border);
+        border-radius: .75rem;
+        transition: border-color .15s ease;
+    }
+
+    .status-online {
+        --card-border: #22c55e;
+    }
+
+    .status-offline {
+        --card-border: #ef4444;
+    }
+
+    .status-checking {
+        --card-border: #f59e0b;
+    }
+
+    @keyframes card-pulse {
+        0% {
+            box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.0);
+        }
+
+        100% {
+            box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.0);
+        }
+    }
+
+    .pulse-now {
+        animation: card-pulse .3s ease-out;
+    }
+</style>
+
+<div class="container-fluid" id="monitoring-page">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="mb-1">Monitoring Services</h1>
+            <p class="text-muted mb-0">Track the live status of your monitored targets.</p>
+        </div>
+        <div class="d-flex flex-column flex-md-row align-items-md-center gap-3">
+            <div class="d-flex align-items-center gap-2">
+                <label class="fw-semibold" for="monitoring-type-filter">Service type</label>
+                <select id="monitoring-type-filter" class="form-select form-select-sm w-auto">
+                    <option value="all">All</option>
+                    <option value="Website">Website</option>
+                    <option value="Api">API</option>
+                    <option value="Tcp">TCP</option>
+                    <option value="Redis">Redis</option>
+                </select>
+            </div>
+            @if (Model.CanRun)
+            {
+                <button id="monitoring-check-all-button" class="btn btn-primary btn-sm">
+                    <i class="fa fa-play-circle me-1"></i>
+                    Check All Now
+                </button>
+            }
+        </div>
+    </div>
+
+    <div id="monitoring-targets-container" class="row g-4"></div>
+</div>
+
+<div class="modal fade" id="monitoring-outages-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="monitoring-outages-modal-title">Recent outages</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="table-responsive">
+                    <table class="table table-sm" id="monitoring-outages-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Started</th>
+                                <th scope="col">Ended</th>
+                                <th scope="col">Duration</th>
+                                <th scope="col">Failures</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+                <p class="text-muted small mb-0">Times are shown in your local timezone.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="monitoring-edit-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <form id="monitoring-edit-form">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="monitoring-edit-modal-title">Edit service</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label class="form-label" for="monitoring-edit-name">Name</label>
+                            <input type="text" class="form-control" id="monitoring-edit-name" name="name" required maxlength="200">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="monitoring-edit-endpoint">Endpoint</label>
+                            <input type="text" class="form-control" id="monitoring-edit-endpoint" name="endpoint" required maxlength="512">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="monitoring-edit-interval">Check interval (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-edit-interval" name="checkIntervalSeconds" min="1" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="monitoring-edit-timeout">Timeout (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-edit-timeout" name="timeoutSeconds" min="1" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="monitoring-edit-retries">Max retries</label>
+                            <input type="number" class="form-control" id="monitoring-edit-retries" name="maxRetryAttempts" min="0" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="monitoring-edit-retry-delay">Retry delay (seconds)</label>
+                            <input type="number" class="form-control" id="monitoring-edit-retry-delay" name="retryDelaySeconds" min="0" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="monitoring-edit-category">Category</label>
+                            <input type="text" class="form-control" id="monitoring-edit-category" name="category" maxlength="100">
+                        </div>
+                        <div class="col-md-6 d-flex align-items-center">
+                            <div class="form-check mt-4">
+                                <input class="form-check-input" type="checkbox" id="monitoring-edit-is-active" name="isActive">
+                                <label class="form-check-label" for="monitoring-edit-is-active">Active</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section scripts {
+    <abp-script src="~/js/monitoring.targets.js"></abp-script>
+    <script>
+        window.monitoringPermissions = {
+            canRun: @Model.CanRun.ToString().ToLowerInvariant(),
+            canEdit: @Model.CanEdit.ToString().ToLowerInvariant(),
+            canDelete: @Model.CanDelete.ToString().ToLowerInvariant()
+        };
+
+        document.addEventListener('DOMContentLoaded', function () {
+            if (window.monitoringTargets) {
+                window.monitoringTargets.init({
+                    container: document.getElementById('monitoring-targets-container'),
+                    filterSelect: document.getElementById('monitoring-type-filter'),
+                    checkAllButton: document.getElementById('monitoring-check-all-button'),
+                    outagesModal: document.getElementById('monitoring-outages-modal'),
+                    outagesModalTitle: document.getElementById('monitoring-outages-modal-title'),
+                    outagesTableBody: document.querySelector('#monitoring-outages-table tbody'),
+                    editModal: document.getElementById('monitoring-edit-modal'),
+                    editModalTitle: document.getElementById('monitoring-edit-modal-title'),
+                    editForm: document.getElementById('monitoring-edit-form')
+                });
+            }
+        });
+    </script>
+}

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml
@@ -23,7 +23,7 @@
         --card-border: #f59e0b;
     }
 
-    @keyframes card-pulse {
+    @@keyframes card-pulse {
         0% {
             box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.0);
         }

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml.cs
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Monitoring.Permissions;
+using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+
+namespace Monitoring.Web.Pages.Monitoring.Targets;
+
+[Authorize(MonitoringPermissions.Services.View)]
+public class IndexModel : AbpPageModel
+{
+    public bool CanRun { get; private set; }
+
+    public bool CanEdit { get; private set; }
+
+    public bool CanDelete { get; private set; }
+
+    public async Task OnGetAsync()
+    {
+        CanRun = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Run);
+        CanEdit = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Edit);
+        CanDelete = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Delete);
+    }
+}

--- a/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml.cs
+++ b/src/Monitoring.Web/Pages/Monitoring/Targets/Index.cshtml.cs
@@ -14,10 +14,13 @@ public class IndexModel : AbpPageModel
 
     public bool CanDelete { get; private set; }
 
+    public bool CanCreate { get; private set; }
+
     public async Task OnGetAsync()
     {
         CanRun = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Run);
         CanEdit = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Edit);
         CanDelete = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Delete);
+        CanCreate = await AuthorizationService.IsGrantedAsync(MonitoringPermissions.Services.Create);
     }
 }

--- a/src/Monitoring.Web/wwwroot/js/monitoring.dashboard.js
+++ b/src/Monitoring.Web/wwwroot/js/monitoring.dashboard.js
@@ -1,0 +1,464 @@
+(function () {
+    const root = document.getElementById('monitoring-dashboard');
+    if (!root) {
+        return;
+    }
+
+    const defaultRangeDays = parseInt(root.dataset.defaultRange, 10) || 7;
+    const maxRangeDays = parseInt(root.dataset.maxRange, 10) || 180;
+
+    const rangeStartInput = document.getElementById('dashboard-range-start');
+    const rangeEndInput = document.getElementById('dashboard-range-end');
+    const typeSelect = document.getElementById('dashboard-type-filter');
+    const targetSelect = document.getElementById('dashboard-target-picker');
+    const applyButton = document.getElementById('dashboard-apply');
+    const summaryEls = {
+        total: document.getElementById('dashboard-total-targets'),
+        online: document.getElementById('dashboard-online'),
+        offline: document.getElementById('dashboard-offline'),
+        uptime: document.getElementById('dashboard-uptime'),
+        incidents: document.getElementById('dashboard-incidents-count'),
+        checking: document.getElementById('dashboard-checking')
+    };
+    const reliabilityEl = document.getElementById('dashboard-reliability');
+    const incidentsTable = document.getElementById('dashboard-incidents-table');
+    const exportUptimeButton = document.getElementById('dashboard-export-uptime');
+    const exportIncidentsButton = document.getElementById('dashboard-export-incidents');
+    const presetButtons = Array.from(root.querySelectorAll('[data-range]'));
+    const chartCanvas = document.getElementById('dashboard-uptime-chart');
+
+    let targetsCache = [];
+    let uptimeChart;
+
+    function setDateInputs(from, to) {
+        rangeStartInput.value = toLocalInputValue(from);
+        rangeEndInput.value = toLocalInputValue(to);
+    }
+
+    function toLocalInputValue(date) {
+        const local = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+        return local.toISOString().slice(0, 16);
+    }
+
+    function parseInputValue(input) {
+        if (!input.value) {
+            return null;
+        }
+
+        const date = new Date(input.value);
+        if (Number.isNaN(date.getTime())) {
+            return null;
+        }
+
+        return date;
+    }
+
+    function clampRange(from, to) {
+        if (to <= from) {
+            to = new Date(from.getTime() + 60 * 60 * 1000);
+        }
+
+        const maxMillis = maxRangeDays * 24 * 60 * 60 * 1000;
+        if (to.getTime() - from.getTime() > maxMillis) {
+            from = new Date(to.getTime() - maxMillis);
+        }
+
+        return { from, to };
+    }
+
+    function formatPercent(value) {
+        if (value === null || value === undefined) {
+            return '—';
+        }
+
+        return `${value.toFixed(2)}%`;
+    }
+
+    function formatDuration(seconds) {
+        if (!seconds || seconds <= 0) {
+            return '—';
+        }
+
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = Math.floor(seconds % 60);
+        const parts = [];
+        if (hours) {
+            parts.push(`${hours}h`);
+        }
+
+        if (minutes) {
+            parts.push(`${minutes}m`);
+        }
+
+        if (secs && parts.length < 2) {
+            parts.push(`${secs}s`);
+        }
+
+        return parts.join(' ') || `${secs}s`;
+    }
+
+    function formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '—';
+        }
+
+        return date.toLocaleString();
+    }
+
+    function getSelectedType() {
+        const value = typeSelect.value;
+        if (!value || value === 'all') {
+            return null;
+        }
+
+        return value;
+    }
+
+    function getSelectedTargetIds() {
+        const value = targetSelect.value;
+        if (!value || value === 'all') {
+            return targetsCache.map(x => x.id);
+        }
+
+        return [value];
+    }
+
+    function determineBucket(from, to) {
+        const diff = to.getTime() - from.getTime();
+        const hours = diff / (60 * 60 * 1000);
+        return hours <= 48 ? 'hour' : 'day';
+    }
+
+    async function fetchJson(url) {
+        const response = await fetch(url, {
+            headers: {
+                Accept: 'application/json'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`Request failed (${response.status})`);
+        }
+
+        return await response.json();
+    }
+
+    function buildQuery(params) {
+        const searchParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined && value !== null && value !== '') {
+                searchParams.append(key, value);
+            }
+        });
+        return searchParams.toString();
+    }
+
+    async function loadTargets() {
+        const type = getSelectedType();
+        const query = type ? `?type=${encodeURIComponent(type)}` : '';
+        const items = await fetchJson(`/api/monitoring/targets/overview${query}`);
+        targetsCache = items.map(item => ({ id: item.id, name: item.name }));
+
+        targetSelect.innerHTML = '<option value="all">All targets</option>';
+        targetsCache.forEach(item => {
+            const option = document.createElement('option');
+            option.value = item.id;
+            option.textContent = item.name;
+            targetSelect.appendChild(option);
+        });
+    }
+
+    async function loadSummary(from, to, type) {
+        const query = buildQuery({
+            from: from.toISOString(),
+            to: to.toISOString(),
+            type
+        });
+
+        const summary = await fetchJson(`/api/monitoring/dashboard/summary?${query}`);
+        summaryEls.total.textContent = summary.totalTargets ?? 0;
+        summaryEls.online.textContent = summary.onlineCount ?? 0;
+        summaryEls.offline.textContent = summary.offlineCount ?? 0;
+        summaryEls.uptime.textContent = formatPercent(summary.uptimePercentage ?? 100);
+        summaryEls.incidents.textContent = summary.incidentsCount ?? 0;
+        summaryEls.checking.textContent = summary.checkingCount ?? 0;
+    }
+
+    async function loadReliability(from, to, type) {
+        reliabilityEl.textContent = 'Loading…';
+        try {
+            const query = buildQuery({
+                from: from.toISOString(),
+                to: to.toISOString(),
+                type
+            });
+            const data = await fetchJson(`/api/monitoring/dashboard/mttr-mtbf?${query}`);
+            const lines = [];
+            if (data.meanTimeToRecoverSeconds != null) {
+                lines.push(`MTTR: ${formatDuration(data.meanTimeToRecoverSeconds)}`);
+            }
+            if (data.meanTimeBetweenFailuresSeconds != null) {
+                lines.push(`MTBF: ${formatDuration(data.meanTimeBetweenFailuresSeconds)}`);
+            }
+
+            if (Array.isArray(data.breakdown) && data.breakdown.length) {
+                lines.push('');
+                data.breakdown.forEach(item => {
+                    const mttr = item.meanTimeToRecoverSeconds != null ? formatDuration(item.meanTimeToRecoverSeconds) : '—';
+                    const mtbf = item.meanTimeBetweenFailuresSeconds != null ? formatDuration(item.meanTimeBetweenFailuresSeconds) : '—';
+                    lines.push(`${item.serviceType}: MTTR ${mttr}, MTBF ${mtbf}`);
+                });
+            }
+
+            reliabilityEl.innerHTML = lines.length ? lines.join('<br>') : 'No outage data in the selected range.';
+        } catch (error) {
+            reliabilityEl.textContent = 'Unable to load reliability metrics.';
+            console.error(error);
+        }
+    }
+
+    async function loadUptimeAndIncidents(from, to) {
+        const bucket = determineBucket(from, to);
+        const targetIds = getSelectedTargetIds();
+        if (!targetIds.length) {
+            clearChart();
+            renderIncidents([]);
+            return;
+        }
+
+        const seriesResponses = await Promise.all(
+            targetIds.map(id => fetchJson(`/api/monitoring/dashboard/uptime/${id}?${buildQuery({
+                from: from.toISOString(),
+                to: to.toISOString(),
+                bucket
+            })}`))
+        );
+
+        let mergedSeries = [];
+        if (seriesResponses.length === 1) {
+            mergedSeries = seriesResponses[0];
+        } else if (seriesResponses.length > 1 && seriesResponses[0].length) {
+            const length = seriesResponses[0].length;
+            mergedSeries = seriesResponses[0].map((bucketItem, index) => {
+                const average = seriesResponses.reduce((sum, series) => {
+                    const item = series[index];
+                    return sum + (item ? item.uptimePercentage ?? 0 : 0);
+                }, 0) / seriesResponses.length;
+                return {
+                    start: bucketItem.start,
+                    end: bucketItem.end,
+                    uptimePercentage: Math.round(average * 100) / 100
+                };
+            });
+        }
+
+        renderChart(mergedSeries, bucket);
+
+        const incidentResponses = await Promise.all(
+            targetIds.map(id => fetchJson(`/api/monitoring/dashboard/incidents/${id}?${buildQuery({
+                from: from.toISOString(),
+                to: to.toISOString(),
+                max: 50
+            })}`))
+        );
+
+        const incidents = incidentResponses
+            .flat()
+            .sort((a, b) => new Date(b.startedAt) - new Date(a.startedAt))
+            .slice(0, 50);
+
+        renderIncidents(incidents);
+    }
+
+    function renderChart(series, bucket) {
+        const labels = series.map(item => new Date(item.start).toLocaleString());
+        const data = series.map(item => item.uptimePercentage ?? 0);
+
+        if (!uptimeChart) {
+            uptimeChart = new Chart(chartCanvas, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: 'Uptime %',
+                            data,
+                            fill: true,
+                            tension: 0.3,
+                            borderColor: 'rgba(37, 99, 235, 1)',
+                            backgroundColor: 'rgba(37, 99, 235, 0.15)',
+                            pointRadius: 2
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        y: {
+                            min: 0,
+                            max: 100,
+                            ticks: {
+                                callback: (value) => `${value}%`
+                            }
+                        }
+                    },
+                    plugins: {
+                        legend: {
+                            display: false
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: (context) => `${context.formattedValue}% uptime`
+                            }
+                        }
+                    }
+                }
+            });
+        } else {
+            uptimeChart.data.labels = labels;
+            uptimeChart.data.datasets[0].data = data;
+            uptimeChart.update();
+        }
+
+        chartCanvas.setAttribute('aria-label', `Uptime trend per ${bucket}`);
+    }
+
+    function clearChart() {
+        if (uptimeChart) {
+            uptimeChart.destroy();
+            uptimeChart = null;
+        }
+        chartCanvas.setAttribute('aria-label', 'Uptime trend');
+    }
+
+    function renderIncidents(incidents) {
+        const tbody = incidentsTable.querySelector('tbody');
+        tbody.innerHTML = '';
+
+        if (!incidents.length) {
+            const row = document.createElement('tr');
+            row.className = 'text-muted';
+            const cell = document.createElement('td');
+            cell.colSpan = 4;
+            cell.textContent = 'No incidents in range.';
+            row.appendChild(cell);
+            tbody.appendChild(row);
+            return;
+        }
+
+        incidents.forEach(item => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${formatDate(item.startedAt)}</td>
+                <td>${item.endedAt ? formatDate(item.endedAt) : 'Ongoing'}</td>
+                <td>${formatDuration(item.totalDurationSec)}</td>
+                <td>${item.failureCount ?? 0}</td>`;
+            tbody.appendChild(row);
+        });
+    }
+
+    function bindExportButtons() {
+        exportUptimeButton.addEventListener('click', () => {
+            const { from, to } = getCurrentRange();
+            const bucket = determineBucket(from, to);
+            const targetIds = getSelectedTargetIds();
+            if (!targetIds.length) {
+                abp.notify.warn('No targets selected for export.');
+                return;
+            }
+
+            if (targetIds.length > 1) {
+                abp.notify.info('Exporting the first target when "All" is selected.');
+            }
+
+            const target = targetIds[0];
+            const query = buildQuery({ from: from.toISOString(), to: to.toISOString(), bucket });
+            window.location.href = `/api/monitoring/export/uptime/${target}.csv?${query}`;
+        });
+
+        exportIncidentsButton.addEventListener('click', () => {
+            const { from, to } = getCurrentRange();
+            const targetIds = getSelectedTargetIds();
+            if (!targetIds.length) {
+                abp.notify.warn('No targets selected for export.');
+                return;
+            }
+
+            if (targetIds.length > 1) {
+                abp.notify.info('Exporting the first target when "All" is selected.');
+            }
+
+            const target = targetIds[0];
+            const query = buildQuery({ from: from.toISOString(), to: to.toISOString() });
+            window.location.href = `/api/monitoring/export/incidents/${target}.csv?${query}`;
+        });
+    }
+
+    function getCurrentRange() {
+        let from = parseInputValue(rangeStartInput) || new Date(Date.now() - defaultRangeDays * 24 * 60 * 60 * 1000);
+        let to = parseInputValue(rangeEndInput) || new Date();
+        return clampRange(from, to);
+    }
+
+    async function refresh() {
+        try {
+            const { from, to } = getCurrentRange();
+            setDateInputs(from, to);
+            const type = getSelectedType();
+            await loadSummary(from, to, type);
+            await loadReliability(from, to, type);
+            await loadUptimeAndIncidents(from, to);
+        } catch (error) {
+            console.error(error);
+            abp.notify.error('Failed to load dashboard data.');
+        }
+    }
+
+    function bindInteractions() {
+        typeSelect.addEventListener('change', async () => {
+            try {
+                await loadTargets();
+                await refresh();
+            } catch (error) {
+                console.error(error);
+                abp.notify.error('Unable to refresh target list.');
+            }
+        });
+
+        applyButton.addEventListener('click', refresh);
+
+        presetButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const preset = parseInt(button.dataset.range, 10);
+                const to = new Date();
+                let from;
+                if (preset <= 48) {
+                    from = new Date(to.getTime() - preset * 60 * 60 * 1000);
+                } else {
+                    from = new Date(to.getTime() - preset * 24 * 60 * 60 * 1000);
+                }
+
+                const clamped = clampRange(from, to);
+                setDateInputs(clamped.from, clamped.to);
+                refresh();
+            });
+        });
+    }
+
+    (async function initialize() {
+        const now = new Date();
+        const from = new Date(now.getTime() - defaultRangeDays * 24 * 60 * 60 * 1000);
+        const clamped = clampRange(from, now);
+        setDateInputs(clamped.from, clamped.to);
+        bindInteractions();
+        bindExportButtons();
+        await loadTargets();
+        await refresh();
+    })();
+})();

--- a/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
+++ b/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
@@ -1,0 +1,660 @@
+(function (window) {
+    const statusLabelMap = {
+        0: 'Online',
+        1: 'Offline',
+        2: 'Checking',
+        online: 'Online',
+        offline: 'Offline',
+        checking: 'Checking'
+    };
+
+    const statusClassMap = {
+        Online: 'status-online',
+        Offline: 'status-offline',
+        Checking: 'status-checking'
+    };
+
+    const typeLabelMap = {
+        0: 'Website',
+        1: 'API',
+        2: 'TCP',
+        3: 'Redis',
+        Website: 'Website',
+        Api: 'API',
+        API: 'API',
+        Tcp: 'TCP',
+        TCP: 'TCP',
+        Redis: 'Redis'
+    };
+
+    const module = {
+        init(options) {
+            this.container = options.container;
+            this.filterSelect = options.filterSelect;
+            this.checkAllButton = options.checkAllButton;
+            this.outagesModalEl = options.outagesModal;
+            this.outagesModalTitle = options.outagesModalTitle;
+            this.outagesTableBody = options.outagesTableBody;
+            this.editModalEl = options.editModal;
+            this.editForm = options.editForm;
+            this.editModalTitle = options.editModalTitle;
+            this.permissions = window.monitoringPermissions || { canRun: false, canEdit: false, canDelete: false };
+
+            this.pulseTimers = [];
+            this.targetCache = new Map();
+            this.currentFilter = 'all';
+            this.editingTargetId = null;
+            this.relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+            if (this.filterSelect) {
+                this.filterSelect.addEventListener('change', () => {
+                    const value = this.filterSelect.value || 'all';
+                    this.fetchTargets(value);
+                });
+            }
+
+            if (this.checkAllButton && !this.permissions.canRun) {
+                this.checkAllButton.classList.add('disabled');
+                this.checkAllButton.setAttribute('disabled', 'disabled');
+            }
+
+            if (this.checkAllButton && this.permissions.canRun) {
+                this.checkAllButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    this.checkAllNow();
+                });
+            }
+
+            if (this.outagesModalEl) {
+                this.outagesModal = new bootstrap.Modal(this.outagesModalEl);
+            }
+
+            if (this.editModalEl) {
+                this.editModal = new bootstrap.Modal(this.editModalEl);
+            }
+
+            if (this.editForm) {
+                this.editForm.addEventListener('submit', (event) => this.submitEdit(event));
+            }
+
+            this.fetchTargets(this.currentFilter);
+        },
+
+        fetchTargets(typeValue) {
+            if (!this.container) {
+                return;
+            }
+
+            this.currentFilter = typeValue || this.currentFilter || 'all';
+            this.clearPulseTimers();
+
+            let url = '/api/monitoring/targets/overview';
+            if (this.currentFilter && this.currentFilter !== 'all') {
+                const params = new URLSearchParams();
+                params.append('type', this.currentFilter);
+                url += `?${params.toString()}`;
+            }
+
+            fetch(url, {
+                headers: {
+                    Accept: 'application/json'
+                }
+            })
+                .then((response) => this.ensureSuccess(response))
+                .then((data) => {
+                    const targets = Array.isArray(data) ? data : [];
+                    this.renderTargets(targets);
+                })
+                .catch((error) => this.handleError(error, 'Failed to load monitoring targets.'));
+        },
+
+        renderTargets(targets) {
+            this.targetCache.clear();
+
+            if (!targets.length) {
+                this.container.innerHTML = '<div class="col-12"><div class="alert alert-info mb-0">No monitoring services found.</div></div>';
+                return;
+            }
+
+            const cardsHtml = targets
+                .map((target) => {
+                    this.targetCache.set(target.id, target);
+                    return this.renderCard(target);
+                })
+                .join('');
+
+            this.container.innerHTML = cardsHtml;
+
+            targets.forEach((target) => {
+                const card = document.getElementById(`monitoring-card-${target.id}`);
+                if (card) {
+                    const interval = Number(target.checkIntervalSeconds) || 0;
+                    this.startPulseTimer(card, interval);
+                }
+            });
+        },
+
+        renderCard(target) {
+            const status = this.resolveStatus(target.currentStatus);
+            const typeLabel = this.resolveType(target.type);
+            const statusClass = statusClassMap[status] || statusClassMap.Checking;
+            const lastChecked = this.relativeTime(target.lastCheckedAt);
+            const nextDue = this.relativeTime(target.nextDueAt);
+
+            const actions = [];
+            if (this.permissions.canRun) {
+                actions.push(`<button type="button" class="btn btn-outline-primary btn-sm" data-action="check" data-id="${target.id}"><i class="fa fa-sync me-1"></i>Check Now</button>`);
+            }
+
+            actions.push(`<button type="button" class="btn btn-outline-secondary btn-sm" data-action="outages" data-id="${target.id}"><i class="fa fa-bolt me-1"></i>View outages</button>`);
+
+            if (this.permissions.canEdit) {
+                actions.push(`<button type="button" class="btn btn-outline-info btn-sm" data-action="edit" data-id="${target.id}"><i class="fa fa-pen me-1"></i>Edit</button>`);
+            }
+
+            if (this.permissions.canDelete) {
+                actions.push(`<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete" data-id="${target.id}"><i class="fa fa-trash me-1"></i>Delete</button>`);
+            }
+
+            const escapedName = this.escapeHtml(target.name);
+            const escapedEndpoint = this.escapeHtml(target.endpoint);
+
+            return `
+                <div class="col-12 col-md-6 col-xl-4">
+                    <div class="status-border ${statusClass} h-100 p-3 bg-white shadow-sm" id="monitoring-card-${target.id}" data-target-id="${target.id}">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <h5 class="mb-1">${escapedName}</h5>
+                                <span class="badge bg-light text-dark">${typeLabel}</span>
+                            </div>
+                        </div>
+                        <div class="mt-3 small">
+                            <div class="mb-1"><span class="text-muted">Endpoint:</span> <span class="text-break">${escapedEndpoint}</span></div>
+                            <div class="mb-1"><span class="text-muted">Status:</span> <span data-role="status-label">${status}</span></div>
+                            <div class="mb-1"><span class="text-muted">Last checked:</span> <span data-role="last-checked">${lastChecked}</span></div>
+                            <div><span class="text-muted">Next check:</span> <span data-role="next-due">${nextDue}</span></div>
+                        </div>
+                        <div class="mt-3 d-flex flex-wrap gap-2">
+                            ${actions.join('')}
+                        </div>
+                    </div>
+                </div>`;
+        },
+
+        relativeTime(iso) {
+            if (!iso) {
+                return '—';
+            }
+
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) {
+                return '—';
+            }
+
+            const now = new Date();
+            let diff = date.getTime() - now.getTime();
+            const absDiff = Math.abs(diff);
+            let unit = 'second';
+            let value = Math.round(diff / 1000);
+
+            if (absDiff >= 1000 * 60 * 60 * 24) {
+                unit = 'day';
+                value = Math.round(diff / (1000 * 60 * 60 * 24));
+            } else if (absDiff >= 1000 * 60 * 60) {
+                unit = 'hour';
+                value = Math.round(diff / (1000 * 60 * 60));
+            } else if (absDiff >= 1000 * 60) {
+                unit = 'minute';
+                value = Math.round(diff / (1000 * 60));
+            }
+
+            return this.relativeTimeFormatter.format(value, unit);
+        },
+
+        startPulseTimer(card, intervalSeconds) {
+            if (!intervalSeconds || intervalSeconds <= 0) {
+                return;
+            }
+
+            const timer = setInterval(() => {
+                card.classList.add('pulse-now');
+                setTimeout(() => card.classList.remove('pulse-now'), 300);
+            }, intervalSeconds * 1000);
+
+            this.pulseTimers.push(timer);
+        },
+
+        clearPulseTimers() {
+            this.pulseTimers.forEach((timer) => clearInterval(timer));
+            this.pulseTimers = [];
+        },
+
+        checkAllNow() {
+            if (!this.permissions.canRun) {
+                return;
+            }
+
+            this.toggleButtonState(this.checkAllButton, true);
+            this.request('/api/monitoring/check-all', { method: 'POST' })
+                .then((count) => {
+                    abp.notify.success(`Queued ${count ?? 0} service checks.`);
+                    this.fetchTargets(this.currentFilter);
+                })
+                .catch((error) => this.handleError(error, 'Failed to queue monitoring checks.'))
+                .finally(() => this.toggleButtonState(this.checkAllButton, false));
+        },
+
+        checkNow(id) {
+            if (!this.permissions.canRun) {
+                return;
+            }
+
+            this.setCardStatus(id, 'Checking');
+
+            this.request(`/api/monitoring/targets/${id}/check`, { method: 'POST' })
+                .then(() => {
+                    abp.notify.success('Health check started.');
+                    this.fetchTargets(this.currentFilter);
+                })
+                .catch((error) => this.handleError(error, 'Failed to start health check.'));
+        },
+
+        showOutages(id) {
+            const target = this.targetCache.get(id);
+            if (!target) {
+                return;
+            }
+
+            if (this.outagesModalTitle) {
+                this.outagesModalTitle.textContent = `${target.name} — recent outages`;
+            }
+
+            if (this.outagesTableBody) {
+                this.outagesTableBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">Loading...</td></tr>';
+            }
+
+            this.getOutages(id)
+                .then((outages) => {
+                    this.renderOutages(outages);
+                })
+                .catch((error) => this.handleError(error, 'Failed to load outage history.'))
+                .finally(() => {
+                    if (this.outagesModal) {
+                        this.outagesModal.show();
+                    }
+                });
+        },
+
+        getOutages(id, count = 10) {
+            const url = `/api/monitoring/targets/${id}/outages?count=${count}`;
+            return this.request(url, { method: 'GET' });
+        },
+
+        renderOutages(outages) {
+            if (!this.outagesTableBody) {
+                return;
+            }
+
+            if (!outages || !outages.length) {
+                this.outagesTableBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">No outages recorded.</td></tr>';
+                return;
+            }
+
+            const rows = outages
+                .map((outage) => {
+                    const started = this.formatDateTime(outage.startedAt);
+                    const ended = outage.endedAt ? this.formatDateTime(outage.endedAt) : 'Ongoing';
+                    const durationSeconds = outage.totalDurationSec ?? this.calculateDurationSeconds(outage.startedAt, outage.endedAt);
+                    const duration = this.formatDuration(durationSeconds);
+                    const failures = outage.failureCount ?? 0;
+
+                    return `<tr>
+                        <td>${started}</td>
+                        <td>${ended}</td>
+                        <td>${duration}</td>
+                        <td>${failures}</td>
+                    </tr>`;
+                })
+                .join('');
+
+            this.outagesTableBody.innerHTML = rows;
+        },
+
+        openEdit(id) {
+            if (!this.permissions.canEdit || !this.editModal) {
+                return;
+            }
+
+            const target = this.targetCache.get(id);
+            if (!target) {
+                return;
+            }
+
+            this.editingTargetId = id;
+
+            this.editForm.querySelector('#monitoring-edit-name').value = target.name ?? '';
+            this.editForm.querySelector('#monitoring-edit-endpoint').value = target.endpoint ?? '';
+            this.editForm.querySelector('#monitoring-edit-interval').value = target.checkIntervalSeconds ?? 0;
+            this.editForm.querySelector('#monitoring-edit-timeout').value = target.timeoutSeconds ?? 0;
+            this.editForm.querySelector('#monitoring-edit-retries').value = target.maxRetryAttempts ?? 0;
+            this.editForm.querySelector('#monitoring-edit-retry-delay').value = target.retryDelaySeconds ?? 0;
+            this.editForm.querySelector('#monitoring-edit-category').value = target.category ?? '';
+            this.editForm.querySelector('#monitoring-edit-is-active').checked = Boolean(target.isActive);
+
+            if (this.editModalTitle) {
+                this.editModalTitle.textContent = `Edit ${target.name}`;
+            }
+
+            this.editModal.show();
+        },
+
+        submitEdit(event) {
+            event.preventDefault();
+
+            if (!this.permissions.canEdit || !this.editingTargetId) {
+                return;
+            }
+
+            const target = this.targetCache.get(this.editingTargetId);
+            if (!target) {
+                return;
+            }
+
+            const formData = new FormData(this.editForm);
+            const payload = {
+                name: formData.get('name') || target.name,
+                type: target.type,
+                endpoint: formData.get('endpoint') || target.endpoint,
+                settingsJson: target.settingsJson ?? null,
+                checkIntervalSeconds: this.toNumber(formData.get('checkIntervalSeconds'), target.checkIntervalSeconds),
+                timeoutSeconds: this.toNumber(formData.get('timeoutSeconds'), target.timeoutSeconds),
+                maxRetryAttempts: this.toNumber(formData.get('maxRetryAttempts'), target.maxRetryAttempts),
+                retryDelaySeconds: this.toNumber(formData.get('retryDelaySeconds'), target.retryDelaySeconds),
+                category: this.normalizeString(formData.get('category')),
+                isActive: formData.get('isActive') === 'on',
+                currentStatus: target.currentStatus,
+                lastCheckedAt: target.lastCheckedAt,
+                lastStatusChangeAt: target.lastStatusChangeAt,
+                nextDueAt: target.nextDueAt,
+                consecutiveFailures: target.consecutiveFailures,
+                firstDownAt: target.firstDownAt,
+                lastUpAt: target.lastUpAt
+            };
+
+            this.toggleButtonState(this.editForm.querySelector('button[type="submit"]'), true);
+
+            this.request(`/api/monitoring/targets/${this.editingTargetId}`, {
+                method: 'PUT',
+                body: payload
+            })
+                .then(() => {
+                    abp.notify.success('Monitoring service updated.');
+                    this.editModal.hide();
+                    this.fetchTargets(this.currentFilter);
+                })
+                .catch((error) => this.handleError(error, 'Failed to update monitoring service.'))
+                .finally(() => this.toggleButtonState(this.editForm.querySelector('button[type="submit"]'), false));
+        },
+
+        deleteTarget(id) {
+            if (!this.permissions.canDelete) {
+                return;
+            }
+
+            abp.message.confirm('This will deactivate the monitoring target. Continue?', 'Delete service')
+                .then((confirmed) => {
+                    if (!confirmed) {
+                        return;
+                    }
+
+                    this.request(`/api/monitoring/targets/${id}`, { method: 'DELETE' })
+                        .then(() => {
+                            abp.notify.success('Monitoring service deleted.');
+                            this.fetchTargets(this.currentFilter);
+                        })
+                        .catch((error) => this.handleError(error, 'Failed to delete monitoring service.'));
+                });
+        },
+
+        setCardStatus(id, statusLabel) {
+            const card = document.getElementById(`monitoring-card-${id}`);
+            if (!card) {
+                return;
+            }
+
+            const normalizedStatus = statusLabelMap[statusLabel?.toLowerCase?.()] || statusLabel;
+            const status = normalizedStatus || 'Checking';
+            const statusClass = statusClassMap[status] || statusClassMap.Checking;
+
+            card.classList.remove('status-online', 'status-offline', 'status-checking');
+            card.classList.add(statusClass);
+
+            const labelEl = card.querySelector('[data-role="status-label"]');
+            if (labelEl) {
+                labelEl.textContent = status;
+            }
+        },
+
+        toggleButtonState(button, isLoading) {
+            if (!button) {
+                return;
+            }
+
+            if (isLoading) {
+                button.setAttribute('disabled', 'disabled');
+                button.dataset.originalText = button.dataset.originalText || button.innerHTML;
+                button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+            } else {
+                button.removeAttribute('disabled');
+                if (button.dataset.originalText) {
+                    button.innerHTML = button.dataset.originalText;
+                    delete button.dataset.originalText;
+                }
+            }
+        },
+
+        ensureSuccess(response) {
+            if (response.ok) {
+                if (response.status === 204) {
+                    return null;
+                }
+
+                const contentType = response.headers.get('content-type') || '';
+                if (contentType.includes('application/json')) {
+                    return response.json();
+                }
+
+                return response.text();
+            }
+
+            throw response;
+        },
+
+        request(url, options) {
+            const requestOptions = Object.assign({
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json'
+                }
+            }, options || {});
+
+            requestOptions.method = (requestOptions.method || 'GET').toUpperCase();
+
+            if (requestOptions.method !== 'GET' && requestOptions.method !== 'HEAD') {
+                requestOptions.headers['Content-Type'] = 'application/json';
+                if (window.abp?.security?.antiForgery) {
+                    requestOptions.headers['RequestVerificationToken'] = window.abp.security.antiForgery.getToken();
+                }
+
+                if (requestOptions.body && typeof requestOptions.body !== 'string') {
+                    requestOptions.body = JSON.stringify(requestOptions.body);
+                } else if (!requestOptions.body) {
+                    requestOptions.body = '{}';
+                }
+            }
+
+            return fetch(url, requestOptions).then((response) => this.ensureSuccess(response));
+        },
+
+        handleError(error, fallbackMessage) {
+            if (error instanceof Response) {
+                return error
+                    .clone()
+                    .json()
+                    .then((payload) => {
+                        const message = payload?.error?.message || payload?.message || fallbackMessage;
+                        abp.notify.error(message);
+                    })
+                    .catch(() => {
+                        error.text().then((text) => {
+                            const message = text || fallbackMessage;
+                            abp.notify.error(message);
+                        });
+                    });
+            }
+
+            const message = error?.message || fallbackMessage;
+            abp.notify.error(message);
+        },
+
+        resolveStatus(value) {
+            if (value === null || value === undefined) {
+                return 'Checking';
+            }
+
+            if (typeof value === 'string') {
+                const normalized = value.trim();
+                return statusLabelMap[normalized] || statusLabelMap[normalized.toLowerCase()] || normalized;
+            }
+
+            if (typeof value === 'number') {
+                return statusLabelMap[value] || 'Checking';
+            }
+
+            return 'Checking';
+        },
+
+        resolveType(value) {
+            if (value === null || value === undefined) {
+                return 'Unknown';
+            }
+
+            if (typeof value === 'string') {
+                const normalized = value.trim();
+                return typeLabelMap[normalized] || typeLabelMap[normalized.charAt(0).toUpperCase() + normalized.slice(1)] || normalized;
+            }
+
+            if (typeof value === 'number') {
+                return typeLabelMap[value] || 'Unknown';
+            }
+
+            return 'Unknown';
+        },
+
+        formatDateTime(value) {
+            if (!value) {
+                return '—';
+            }
+
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return '—';
+            }
+
+            return date.toLocaleString();
+        },
+
+        calculateDurationSeconds(startedAt, endedAt) {
+            const start = new Date(startedAt);
+            const end = endedAt ? new Date(endedAt) : new Date();
+
+            if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+                return 0;
+            }
+
+            const seconds = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000));
+            return seconds;
+        },
+
+        formatDuration(seconds) {
+            if (seconds === null || seconds === undefined || seconds < 0) {
+                return '—';
+            }
+
+            const hrs = Math.floor(seconds / 3600)
+                .toString()
+                .padStart(2, '0');
+            const mins = Math.floor((seconds % 3600) / 60)
+                .toString()
+                .padStart(2, '0');
+            const secs = Math.floor(seconds % 60)
+                .toString()
+                .padStart(2, '0');
+
+            return `${hrs}:${mins}:${secs}`;
+        },
+
+        escapeHtml(value) {
+            if (value === null || value === undefined) {
+                return '';
+            }
+
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        },
+
+        toNumber(value, fallback) {
+            const parsed = Number(value);
+            if (Number.isNaN(parsed)) {
+                return fallback ?? 0;
+            }
+
+            return parsed;
+        },
+
+        normalizeString(value) {
+            if (value === null || value === undefined) {
+                return null;
+            }
+
+            const trimmed = String(value).trim();
+            return trimmed.length ? trimmed : null;
+        }
+    };
+
+    document.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-action]');
+        if (!target) {
+            return;
+        }
+
+        const action = target.getAttribute('data-action');
+        const id = target.getAttribute('data-id');
+        if (!action || !id || !window.monitoringTargets) {
+            return;
+        }
+
+        switch (action) {
+            case 'check':
+                window.monitoringTargets.checkNow(id);
+                break;
+            case 'outages':
+                window.monitoringTargets.showOutages(id);
+                break;
+            case 'edit':
+                window.monitoringTargets.openEdit(id);
+                break;
+            case 'delete':
+                window.monitoringTargets.deleteTarget(id);
+                break;
+            default:
+                break;
+        }
+    });
+
+    window.monitoringTargets = module;
+})(window);

--- a/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
+++ b/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
@@ -27,103 +27,222 @@
         Redis: 'Redis'
     };
 
+    const defaultPageSize = 12;
+
     const module = {
         init(options) {
             this.container = options.container;
             this.filterSelect = options.filterSelect;
+            this.searchInput = options.searchInput;
+            this.sortSelect = options.sortSelect;
             this.checkAllButton = options.checkAllButton;
+            this.newButton = options.newButton;
             this.outagesModalEl = options.outagesModal;
             this.outagesModalTitle = options.outagesModalTitle;
             this.outagesTableBody = options.outagesTableBody;
-            this.editModalEl = options.editModal;
-            this.editForm = options.editForm;
-            this.editModalTitle = options.editModalTitle;
-            this.permissions = window.monitoringPermissions || { canRun: false, canEdit: false, canDelete: false };
+            this.manageModalEl = options.manageModal;
+            this.manageForm = options.manageForm;
+            this.manageErrors = options.manageErrors;
+            this.manageSubmitButton = options.manageSubmitButton;
+            this.pageInfo = options.pageInfo;
+            this.prevButton = options.prevButton;
+            this.nextButton = options.nextButton;
+            this.permissions = window.monitoringPermissions || { canRun: false, canEdit: false, canDelete: false, canCreate: false };
 
             this.pulseTimers = [];
             this.targetCache = new Map();
-            this.currentFilter = 'all';
-            this.editingTargetId = null;
             this.relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-            if (this.filterSelect) {
-                this.filterSelect.addEventListener('change', () => {
-                    const value = this.filterSelect.value || 'all';
-                    this.fetchTargets(value);
-                });
-            }
-
-            if (this.checkAllButton && !this.permissions.canRun) {
-                this.checkAllButton.classList.add('disabled');
-                this.checkAllButton.setAttribute('disabled', 'disabled');
-            }
-
-            if (this.checkAllButton && this.permissions.canRun) {
-                this.checkAllButton.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    this.checkAllNow();
-                });
-            }
+            this.state = this.readInitialState();
+            this.searchDebounceHandle = null;
+            this.formMode = 'create';
+            this.editingTargetId = null;
 
             if (this.outagesModalEl) {
                 this.outagesModal = new bootstrap.Modal(this.outagesModalEl);
             }
 
-            if (this.editModalEl) {
-                this.editModal = new bootstrap.Modal(this.editModalEl);
+            if (this.manageModalEl) {
+                this.manageModal = new bootstrap.Modal(this.manageModalEl);
+                this.manageModalEl.addEventListener('hidden.bs.modal', () => this.resetForm());
             }
 
-            if (this.editForm) {
-                this.editForm.addEventListener('submit', (event) => this.submitEdit(event));
-            }
-
-            this.fetchTargets(this.currentFilter);
+            this.applyStateToControls();
+            this.bindEvents();
+            this.refresh(true);
         },
 
-        fetchTargets(typeValue) {
+        readInitialState() {
+            const params = new URLSearchParams(window.location.search);
+            const type = params.get('type') || 'all';
+            const search = params.get('search') || '';
+            const sorting = params.get('sorting') || 'Name';
+            const skipCount = Math.max(Number.parseInt(params.get('skipCount') || '0', 10) || 0, 0);
+            const maxResultCount = Math.max(Number.parseInt(params.get('maxResultCount') || defaultPageSize.toString(), 10) || defaultPageSize, 1);
+
+            return {
+                type,
+                search,
+                sorting,
+                skipCount,
+                maxResultCount: Math.min(maxResultCount, 100)
+            };
+        },
+
+        applyStateToControls() {
+            if (this.filterSelect) {
+                this.filterSelect.value = this.state.type || 'all';
+            }
+
+            if (this.searchInput) {
+                this.searchInput.value = this.state.search;
+            }
+
+            if (this.sortSelect) {
+                this.sortSelect.value = this.state.sorting;
+            }
+        },
+
+        bindEvents() {
+            if (this.filterSelect) {
+                this.filterSelect.addEventListener('change', () => {
+                    this.state.type = this.filterSelect.value || 'all';
+                    this.state.skipCount = 0;
+                    this.refresh();
+                });
+            }
+
+            if (this.searchInput) {
+                this.searchInput.addEventListener('input', () => {
+                    clearTimeout(this.searchDebounceHandle);
+                    this.searchDebounceHandle = setTimeout(() => {
+                        this.state.search = (this.searchInput.value || '').trim();
+                        this.state.skipCount = 0;
+                        this.refresh();
+                    }, 300);
+                });
+            }
+
+            if (this.sortSelect) {
+                this.sortSelect.addEventListener('change', () => {
+                    this.state.sorting = this.sortSelect.value || 'Name';
+                    this.state.skipCount = 0;
+                    this.refresh();
+                });
+            }
+
+            if (this.checkAllButton) {
+                if (!this.permissions.canRun) {
+                    this.checkAllButton.classList.add('disabled');
+                    this.checkAllButton.setAttribute('disabled', 'disabled');
+                } else {
+                    this.checkAllButton.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        this.checkAllNow();
+                    });
+                }
+            }
+
+            if (this.newButton) {
+                if (!this.permissions.canCreate) {
+                    this.newButton.classList.add('disabled');
+                    this.newButton.setAttribute('disabled', 'disabled');
+                } else {
+                    this.newButton.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        this.openCreate();
+                    });
+                }
+            }
+
+            if (this.manageForm) {
+                this.manageForm.addEventListener('submit', (event) => this.submitManageForm(event));
+            }
+
+            if (this.prevButton) {
+                this.prevButton.addEventListener('click', () => {
+                    if (this.state.skipCount <= 0) {
+                        return;
+                    }
+
+                    this.state.skipCount = Math.max(0, this.state.skipCount - this.state.maxResultCount);
+                    this.refresh();
+                });
+            }
+
+            if (this.nextButton) {
+                this.nextButton.addEventListener('click', () => {
+                    const nextSkip = this.state.skipCount + this.state.maxResultCount;
+                    if (nextSkip >= (this.totalCount || 0)) {
+                        return;
+                    }
+
+                    this.state.skipCount = nextSkip;
+                    this.refresh();
+                });
+            }
+        },
+
+        refresh(updateHistory = true) {
             if (!this.container) {
                 return;
             }
 
-            this.currentFilter = typeValue || this.currentFilter || 'all';
             this.clearPulseTimers();
+            this.container.innerHTML = '<div class="col-12"><div class="alert alert-info mb-0">Loading services…</div></div>';
 
-            let url = '/api/monitoring/targets/overview';
-            if (this.currentFilter && this.currentFilter !== 'all') {
-                const params = new URLSearchParams();
-                params.append('type', this.currentFilter);
-                url += `?${params.toString()}`;
-            }
-
-            fetch(url, {
-                headers: {
-                    Accept: 'application/json'
-                }
-            })
-                .then((response) => this.ensureSuccess(response))
-                .then((data) => {
-                    const targets = Array.isArray(data) ? data : [];
-                    this.renderTargets(targets);
+            this.getTargets(this.buildQueryParams())
+                .then((result) => {
+                    this.totalCount = result.totalCount || 0;
+                    const items = Array.isArray(result.items) ? result.items : [];
+                    this.renderTargets(items);
+                    this.renderPager();
+                    if (updateHistory) {
+                        this.updateHistory();
+                    }
                 })
                 .catch((error) => this.handleError(error, 'Failed to load monitoring targets.'));
+        },
+
+        buildQueryParams() {
+            const params = new URLSearchParams();
+            params.set('skipCount', this.state.skipCount.toString());
+            params.set('maxResultCount', this.state.maxResultCount.toString());
+
+            if (this.state.sorting) {
+                params.set('sorting', this.state.sorting);
+            }
+
+            if (this.state.type && this.state.type !== 'all') {
+                params.set('type', this.state.type);
+            }
+
+            if (this.state.search) {
+                params.set('search', this.state.search);
+            }
+
+            return params;
+        },
+
+        updateHistory() {
+            const params = this.buildQueryParams();
+            const url = `${window.location.pathname}?${params.toString()}`;
+            window.history.replaceState({}, '', url);
         },
 
         renderTargets(targets) {
             this.targetCache.clear();
 
             if (!targets.length) {
-                this.container.innerHTML = '<div class="col-12"><div class="alert alert-info mb-0">No monitoring services found.</div></div>';
+                this.container.innerHTML = '<div class="col-12"><div class="alert alert-warning mb-0">No monitoring services matched your filters.</div></div>';
                 return;
             }
 
-            const cardsHtml = targets
-                .map((target) => {
-                    this.targetCache.set(target.id, target);
-                    return this.renderCard(target);
-                })
-                .join('');
+            const cards = targets.map((target) => {
+                this.targetCache.set(target.id, target);
+                return this.renderCard(target);
+            });
 
-            this.container.innerHTML = cardsHtml;
+            this.container.innerHTML = cards.join('');
 
             targets.forEach((target) => {
                 const card = document.getElementById(`monitoring-card-${target.id}`);
@@ -142,18 +261,19 @@
             const nextDue = this.relativeTime(target.nextDueAt);
 
             const actions = [];
+
             if (this.permissions.canRun) {
-                actions.push(`<button type="button" class="btn btn-outline-primary btn-sm" data-action="check" data-id="${target.id}"><i class="fa fa-sync me-1"></i>Check Now</button>`);
+                actions.push(`<button type="button" class="btn btn-outline-primary btn-sm" data-action="check" data-id="${target.id}" aria-label="Check ${this.escapeHtml(target.name)} now"><i class="fa fa-sync me-1" aria-hidden="true"></i>Check Now</button>`);
             }
 
-            actions.push(`<button type="button" class="btn btn-outline-secondary btn-sm" data-action="outages" data-id="${target.id}"><i class="fa fa-bolt me-1"></i>View outages</button>`);
+            actions.push(`<button type="button" class="btn btn-outline-secondary btn-sm" data-action="outages" data-id="${target.id}" aria-label="View outages for ${this.escapeHtml(target.name)}"><i class="fa fa-bolt me-1" aria-hidden="true"></i>View outages</button>`);
 
             if (this.permissions.canEdit) {
-                actions.push(`<button type="button" class="btn btn-outline-info btn-sm" data-action="edit" data-id="${target.id}"><i class="fa fa-pen me-1"></i>Edit</button>`);
+                actions.push(`<button type="button" class="btn btn-outline-info btn-sm" data-action="edit" data-id="${target.id}" aria-label="Edit ${this.escapeHtml(target.name)}"><i class="fa fa-pen me-1" aria-hidden="true"></i>Edit</button>`);
             }
 
             if (this.permissions.canDelete) {
-                actions.push(`<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete" data-id="${target.id}"><i class="fa fa-trash me-1"></i>Delete</button>`);
+                actions.push(`<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete" data-id="${target.id}" aria-label="Delete ${this.escapeHtml(target.name)}"><i class="fa fa-trash me-1" aria-hidden="true"></i>Delete</button>`);
             }
 
             const escapedName = this.escapeHtml(target.name);
@@ -181,56 +301,254 @@
                 </div>`;
         },
 
-        relativeTime(iso) {
-            if (!iso) {
-                return '—';
-            }
-
-            const date = new Date(iso);
-            if (Number.isNaN(date.getTime())) {
-                return '—';
-            }
-
-            const now = new Date();
-            let diff = date.getTime() - now.getTime();
-            const absDiff = Math.abs(diff);
-            let unit = 'second';
-            let value = Math.round(diff / 1000);
-
-            if (absDiff >= 1000 * 60 * 60 * 24) {
-                unit = 'day';
-                value = Math.round(diff / (1000 * 60 * 60 * 24));
-            } else if (absDiff >= 1000 * 60 * 60) {
-                unit = 'hour';
-                value = Math.round(diff / (1000 * 60 * 60));
-            } else if (absDiff >= 1000 * 60) {
-                unit = 'minute';
-                value = Math.round(diff / (1000 * 60));
-            }
-
-            return this.relativeTimeFormatter.format(value, unit);
-        },
-
-        startPulseTimer(card, intervalSeconds) {
-            if (!intervalSeconds || intervalSeconds <= 0) {
+        renderPager() {
+            if (!this.pageInfo || !this.prevButton || !this.nextButton) {
                 return;
             }
 
-            const timer = setInterval(() => {
-                card.classList.add('pulse-now');
-                setTimeout(() => card.classList.remove('pulse-now'), 300);
-            }, intervalSeconds * 1000);
+            const total = this.totalCount || 0;
+            if (total === 0) {
+                this.pageInfo.textContent = 'No services found';
+                this.prevButton.setAttribute('disabled', 'disabled');
+                this.nextButton.setAttribute('disabled', 'disabled');
+                return;
+            }
 
-            this.pulseTimers.push(timer);
+            const pageSize = this.state.maxResultCount;
+            const currentPage = Math.floor(this.state.skipCount / pageSize) + 1;
+            const totalPages = Math.max(1, Math.ceil(total / pageSize));
+            const start = this.state.skipCount + 1;
+            const end = Math.min(total, this.state.skipCount + pageSize);
+
+            this.pageInfo.textContent = `Showing ${start}–${end} of ${total}`;
+
+            if (currentPage <= 1) {
+                this.prevButton.setAttribute('disabled', 'disabled');
+            } else {
+                this.prevButton.removeAttribute('disabled');
+            }
+
+            if (currentPage >= totalPages) {
+                this.nextButton.setAttribute('disabled', 'disabled');
+            } else {
+                this.nextButton.removeAttribute('disabled');
+            }
         },
 
-        clearPulseTimers() {
-            this.pulseTimers.forEach((timer) => clearInterval(timer));
-            this.pulseTimers = [];
+        openCreate() {
+            if (!this.permissions.canCreate || !this.manageModal) {
+                return;
+            }
+
+            this.formMode = 'create';
+            this.editingTargetId = null;
+            this.resetForm();
+            this.setFormDefaults();
+            this.setFormTitle('New service');
+            this.setSubmitLabel('Create');
+            this.manageModal.show();
+        },
+
+        openEdit(id) {
+            if (!this.permissions.canEdit || !this.manageModal) {
+                return;
+            }
+
+            const target = this.targetCache.get(id);
+            if (!target) {
+                this.handleError(null, 'Unable to load the selected service. Please refresh and try again.');
+                return;
+            }
+
+            this.formMode = 'edit';
+            this.editingTargetId = id;
+            this.resetForm();
+            this.populateForm(target);
+            this.setFormTitle(`Edit ${target.name}`);
+            this.setSubmitLabel('Save changes');
+            this.manageModal.show();
+        },
+
+        setFormDefaults() {
+            if (!this.manageForm) {
+                return;
+            }
+
+            this.manageForm.reset();
+            this.manageForm.querySelector('#monitoring-manage-type').value = '0';
+            this.manageForm.querySelector('#monitoring-manage-interval').value = 300;
+            this.manageForm.querySelector('#monitoring-manage-timeout').value = 30;
+            this.manageForm.querySelector('#monitoring-manage-retries').value = 3;
+            this.manageForm.querySelector('#monitoring-manage-retry-delay').value = 30;
+            this.manageForm.querySelector('#monitoring-manage-is-active').checked = true;
+        },
+
+        populateForm(target) {
+            if (!this.manageForm) {
+                return;
+            }
+
+            this.manageForm.querySelector('#monitoring-manage-name').value = target.name ?? '';
+            this.manageForm.querySelector('#monitoring-manage-type').value = this.resolveTypeValue(target.type);
+            this.manageForm.querySelector('#monitoring-manage-endpoint').value = target.endpoint ?? '';
+            this.manageForm.querySelector('#monitoring-manage-settings').value = target.settingsJson ?? '';
+            this.manageForm.querySelector('#monitoring-manage-interval').value = target.checkIntervalSeconds ?? 300;
+            this.manageForm.querySelector('#monitoring-manage-timeout').value = target.timeoutSeconds ?? 30;
+            this.manageForm.querySelector('#monitoring-manage-retries').value = target.maxRetryAttempts ?? 0;
+            this.manageForm.querySelector('#monitoring-manage-retry-delay').value = target.retryDelaySeconds ?? 1;
+            this.manageForm.querySelector('#monitoring-manage-category').value = target.category ?? '';
+            this.manageForm.querySelector('#monitoring-manage-is-active').checked = Boolean(target.isActive);
+        },
+
+        resetForm() {
+            if (this.manageErrors) {
+                this.manageErrors.classList.add('d-none');
+                this.manageErrors.textContent = '';
+            }
+
+            if (this.manageForm) {
+                this.manageForm.reset();
+            }
+        },
+
+        setFormTitle(title) {
+            const heading = document.getElementById('monitoring-manage-modal-title');
+            if (heading) {
+                heading.textContent = title;
+            }
+        },
+
+        setSubmitLabel(label) {
+            if (!this.manageSubmitButton) {
+                return;
+            }
+
+            const labelSpan = this.manageSubmitButton.querySelector('[data-role="submit-label"]');
+            if (labelSpan) {
+                labelSpan.textContent = label;
+            }
+        },
+
+        submitManageForm(event) {
+            event.preventDefault();
+
+            if (!this.manageForm || !this.manageSubmitButton) {
+                return;
+            }
+
+            const formData = new FormData(this.manageForm);
+            const settings = (formData.get('settingsJson') || '').toString().trim();
+            if (!this.validateJson(settings)) {
+                this.showFormError('Settings JSON is invalid.');
+                return;
+            }
+
+            const typeValue = formData.get('type')?.toString() || '0';
+
+            const payload = {
+                name: formData.get('name')?.toString().trim() || '',
+                type: this.toNumber(typeValue, 0),
+                endpoint: formData.get('endpoint')?.toString().trim() || '',
+                settingsJson: settings.length ? settings : null,
+                checkIntervalSeconds: this.toNumber(formData.get('checkIntervalSeconds'), 300),
+                timeoutSeconds: this.toNumber(formData.get('timeoutSeconds'), 30),
+                maxRetryAttempts: this.toNumber(formData.get('maxRetryAttempts'), 0),
+                retryDelaySeconds: this.toNumber(formData.get('retryDelaySeconds'), 1),
+                category: this.normalizeString(formData.get('category')),
+                isActive: formData.get('isActive') === 'on'
+            };
+
+            if (!payload.name || payload.name.length < 2) {
+                this.showFormError('Name must be at least 2 characters.');
+                return;
+            }
+
+            if (!payload.endpoint) {
+                this.showFormError('Endpoint is required.');
+                return;
+            }
+
+            this.showFormError(null);
+            this.toggleButtonState(this.manageSubmitButton, true);
+
+            const request = this.formMode === 'edit' && this.editingTargetId
+                ? this.updateTarget(this.editingTargetId, payload)
+                : this.createTarget(payload);
+
+            request
+                .then(() => {
+                    const message = this.formMode === 'edit' ? 'Monitoring service updated.' : 'Monitoring service created.';
+                    abp.notify.success(message);
+                    this.manageModal.hide();
+                    if (this.formMode !== 'edit') {
+                        this.state.skipCount = 0;
+                    }
+                    this.refresh();
+                })
+                .catch((error) => this.handleError(error, 'Failed to save monitoring service.', true))
+                .finally(() => this.toggleButtonState(this.manageSubmitButton, false));
+        },
+
+        showFormError(message) {
+            if (!this.manageErrors) {
+                return;
+            }
+
+            if (!message) {
+                this.manageErrors.classList.add('d-none');
+                this.manageErrors.textContent = '';
+                return;
+            }
+
+            this.manageErrors.textContent = message;
+            this.manageErrors.classList.remove('d-none');
+        },
+
+        getTargets(params) {
+            const url = `/api/monitoring/targets?${params.toString()}`;
+            return this.request(url, { method: 'GET' });
+        },
+
+        createTarget(dto) {
+            return this.request('/api/monitoring/targets', {
+                method: 'POST',
+                body: dto
+            });
+        },
+
+        updateTarget(id, dto) {
+            return this.request(`/api/monitoring/targets/${id}`, {
+                method: 'PUT',
+                body: dto
+            });
+        },
+
+        deleteTarget(id) {
+            if (!this.permissions.canDelete) {
+                return;
+            }
+
+            abp.message
+                .confirm('This will deactivate the monitoring target. Continue?', 'Delete service')
+                .then((confirmed) => {
+                    if (!confirmed) {
+                        return;
+                    }
+
+                    this.request(`/api/monitoring/targets/${id}`, { method: 'DELETE' })
+                        .then(() => {
+                            abp.notify.success('Monitoring service deleted.');
+                            if (this.targetCache.size <= 1 && this.state.skipCount > 0) {
+                                this.state.skipCount = Math.max(0, this.state.skipCount - this.state.maxResultCount);
+                            }
+                            this.refresh();
+                        })
+                        .catch((error) => this.handleError(error, 'Failed to delete monitoring service.'));
+                });
         },
 
         checkAllNow() {
-            if (!this.permissions.canRun) {
+            if (!this.permissions.canRun || !this.checkAllButton) {
                 return;
             }
 
@@ -238,7 +556,7 @@
             this.request('/api/monitoring/check-all', { method: 'POST' })
                 .then((count) => {
                     abp.notify.success(`Queued ${count ?? 0} service checks.`);
-                    this.fetchTargets(this.currentFilter);
+                    this.refresh(false);
                 })
                 .catch((error) => this.handleError(error, 'Failed to queue monitoring checks.'))
                 .finally(() => this.toggleButtonState(this.checkAllButton, false));
@@ -254,7 +572,7 @@
             this.request(`/api/monitoring/targets/${id}/check`, { method: 'POST' })
                 .then(() => {
                     abp.notify.success('Health check started.');
-                    this.fetchTargets(this.currentFilter);
+                    this.refresh(false);
                 })
                 .catch((error) => this.handleError(error, 'Failed to start health check.'));
         },
@@ -270,13 +588,11 @@
             }
 
             if (this.outagesTableBody) {
-                this.outagesTableBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">Loading...</td></tr>';
+                this.outagesTableBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">Loading…</td></tr>';
             }
 
             this.getOutages(id)
-                .then((outages) => {
-                    this.renderOutages(outages);
-                })
+                .then((outages) => this.renderOutages(outages))
                 .catch((error) => this.handleError(error, 'Failed to load outage history.'))
                 .finally(() => {
                     if (this.outagesModal) {
@@ -320,100 +636,92 @@
             this.outagesTableBody.innerHTML = rows;
         },
 
-        openEdit(id) {
-            if (!this.permissions.canEdit || !this.editModal) {
-                return;
+        request(url, options) {
+            const init = options || {};
+            init.headers = init.headers || { 'Accept': 'application/json' };
+
+            if (init.body && typeof init.body === 'object' && !(init.body instanceof FormData)) {
+                init.headers['Content-Type'] = 'application/json';
+                init.body = JSON.stringify(init.body);
             }
 
-            const target = this.targetCache.get(id);
-            if (!target) {
-                return;
-            }
-
-            this.editingTargetId = id;
-
-            this.editForm.querySelector('#monitoring-edit-name').value = target.name ?? '';
-            this.editForm.querySelector('#monitoring-edit-endpoint').value = target.endpoint ?? '';
-            this.editForm.querySelector('#monitoring-edit-interval').value = target.checkIntervalSeconds ?? 0;
-            this.editForm.querySelector('#monitoring-edit-timeout').value = target.timeoutSeconds ?? 0;
-            this.editForm.querySelector('#monitoring-edit-retries').value = target.maxRetryAttempts ?? 0;
-            this.editForm.querySelector('#monitoring-edit-retry-delay').value = target.retryDelaySeconds ?? 0;
-            this.editForm.querySelector('#monitoring-edit-category').value = target.category ?? '';
-            this.editForm.querySelector('#monitoring-edit-is-active').checked = Boolean(target.isActive);
-
-            if (this.editModalTitle) {
-                this.editModalTitle.textContent = `Edit ${target.name}`;
-            }
-
-            this.editModal.show();
+            return fetch(url, init).then((response) => this.ensureSuccess(response));
         },
 
-        submitEdit(event) {
-            event.preventDefault();
+        ensureSuccess(response) {
+            if (response.ok) {
+                if (response.status === 204) {
+                    return null;
+                }
 
-            if (!this.permissions.canEdit || !this.editingTargetId) {
-                return;
+                return response.json();
             }
 
-            const target = this.targetCache.get(this.editingTargetId);
-            if (!target) {
-                return;
-            }
-
-            const formData = new FormData(this.editForm);
-            const payload = {
-                name: formData.get('name') || target.name,
-                type: target.type,
-                endpoint: formData.get('endpoint') || target.endpoint,
-                settingsJson: target.settingsJson ?? null,
-                checkIntervalSeconds: this.toNumber(formData.get('checkIntervalSeconds'), target.checkIntervalSeconds),
-                timeoutSeconds: this.toNumber(formData.get('timeoutSeconds'), target.timeoutSeconds),
-                maxRetryAttempts: this.toNumber(formData.get('maxRetryAttempts'), target.maxRetryAttempts),
-                retryDelaySeconds: this.toNumber(formData.get('retryDelaySeconds'), target.retryDelaySeconds),
-                category: this.normalizeString(formData.get('category')),
-                isActive: formData.get('isActive') === 'on',
-                currentStatus: target.currentStatus,
-                lastCheckedAt: target.lastCheckedAt,
-                lastStatusChangeAt: target.lastStatusChangeAt,
-                nextDueAt: target.nextDueAt,
-                consecutiveFailures: target.consecutiveFailures,
-                firstDownAt: target.firstDownAt,
-                lastUpAt: target.lastUpAt
-            };
-
-            this.toggleButtonState(this.editForm.querySelector('button[type="submit"]'), true);
-
-            this.request(`/api/monitoring/targets/${this.editingTargetId}`, {
-                method: 'PUT',
-                body: payload
-            })
-                .then(() => {
-                    abp.notify.success('Monitoring service updated.');
-                    this.editModal.hide();
-                    this.fetchTargets(this.currentFilter);
-                })
-                .catch((error) => this.handleError(error, 'Failed to update monitoring service.'))
-                .finally(() => this.toggleButtonState(this.editForm.querySelector('button[type="submit"]'), false));
+            return response
+                .json()
+                .catch(() => ({ error: { message: response.statusText } }))
+                .then((payload) => Promise.reject(payload));
         },
 
-        deleteTarget(id) {
-            if (!this.permissions.canDelete) {
+        handleError(error, fallbackMessage, isFormError) {
+            const message = this.extractErrorMessage(error) || fallbackMessage || 'An unexpected error occurred.';
+
+            if (isFormError) {
+                this.showFormError(message);
                 return;
             }
 
-            abp.message.confirm('This will deactivate the monitoring target. Continue?', 'Delete service')
-                .then((confirmed) => {
-                    if (!confirmed) {
-                        return;
-                    }
+            abp.notify.error(message);
+        },
 
-                    this.request(`/api/monitoring/targets/${id}`, { method: 'DELETE' })
-                        .then(() => {
-                            abp.notify.success('Monitoring service deleted.');
-                            this.fetchTargets(this.currentFilter);
-                        })
-                        .catch((error) => this.handleError(error, 'Failed to delete monitoring service.'));
-                });
+        extractErrorMessage(error) {
+            if (!error) {
+                return null;
+            }
+
+            if (typeof error === 'string') {
+                return error;
+            }
+
+            const payload = error.error || error;
+            if (payload) {
+                if (Array.isArray(payload.validationErrors) && payload.validationErrors.length) {
+                    return payload.validationErrors.map((e) => e.message || e).join('\n');
+                }
+
+                if (payload.message) {
+                    return payload.message;
+                }
+            }
+
+            return null;
+        },
+
+        toggleButtonState(button, isLoading) {
+            if (!button) {
+                return;
+            }
+
+            const spinner = button.querySelector('.spinner-border');
+            const label = button.querySelector('[data-role="submit-label"]');
+
+            if (isLoading) {
+                button.setAttribute('disabled', 'disabled');
+                if (spinner) {
+                    spinner.classList.remove('d-none');
+                }
+                if (label) {
+                    label.classList.add('opacity-75');
+                }
+            } else {
+                button.removeAttribute('disabled');
+                if (spinner) {
+                    spinner.classList.add('d-none');
+                }
+                if (label) {
+                    label.classList.remove('opacity-75');
+                }
+            }
         },
 
         setCardStatus(id, statusLabel) {
@@ -435,86 +743,52 @@
             }
         },
 
-        toggleButtonState(button, isLoading) {
-            if (!button) {
+        clearPulseTimers() {
+            this.pulseTimers.forEach((timer) => clearInterval(timer));
+            this.pulseTimers = [];
+        },
+
+        startPulseTimer(card, intervalSeconds) {
+            if (!intervalSeconds || intervalSeconds <= 0) {
                 return;
             }
 
-            if (isLoading) {
-                button.setAttribute('disabled', 'disabled');
-                button.dataset.originalText = button.dataset.originalText || button.innerHTML;
-                button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
-            } else {
-                button.removeAttribute('disabled');
-                if (button.dataset.originalText) {
-                    button.innerHTML = button.dataset.originalText;
-                    delete button.dataset.originalText;
-                }
-            }
+            const timer = setInterval(() => {
+                card.classList.add('pulse-now');
+                setTimeout(() => card.classList.remove('pulse-now'), 300);
+            }, intervalSeconds * 1000);
+
+            this.pulseTimers.push(timer);
         },
 
-        ensureSuccess(response) {
-            if (response.ok) {
-                if (response.status === 204) {
-                    return null;
-                }
-
-                const contentType = response.headers.get('content-type') || '';
-                if (contentType.includes('application/json')) {
-                    return response.json();
-                }
-
-                return response.text();
+        relativeTime(iso) {
+            if (!iso) {
+                return '—';
             }
 
-            throw response;
-        },
-
-        request(url, options) {
-            const requestOptions = Object.assign({
-                method: 'GET',
-                headers: {
-                    Accept: 'application/json'
-                }
-            }, options || {});
-
-            requestOptions.method = (requestOptions.method || 'GET').toUpperCase();
-
-            if (requestOptions.method !== 'GET' && requestOptions.method !== 'HEAD') {
-                requestOptions.headers['Content-Type'] = 'application/json';
-                if (window.abp?.security?.antiForgery) {
-                    requestOptions.headers['RequestVerificationToken'] = window.abp.security.antiForgery.getToken();
-                }
-
-                if (requestOptions.body && typeof requestOptions.body !== 'string') {
-                    requestOptions.body = JSON.stringify(requestOptions.body);
-                } else if (!requestOptions.body) {
-                    requestOptions.body = '{}';
-                }
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) {
+                return '—';
             }
 
-            return fetch(url, requestOptions).then((response) => this.ensureSuccess(response));
-        },
+            const now = new Date();
+            let diff = date.getTime() - now.getTime();
+            const absDiff = Math.abs(diff);
+            let unit = 'second';
+            let value = Math.round(diff / 1000);
 
-        handleError(error, fallbackMessage) {
-            if (error instanceof Response) {
-                return error
-                    .clone()
-                    .json()
-                    .then((payload) => {
-                        const message = payload?.error?.message || payload?.message || fallbackMessage;
-                        abp.notify.error(message);
-                    })
-                    .catch(() => {
-                        error.text().then((text) => {
-                            const message = text || fallbackMessage;
-                            abp.notify.error(message);
-                        });
-                    });
+            if (absDiff >= 1000 * 60 * 60 * 24) {
+                unit = 'day';
+                value = Math.round(diff / (1000 * 60 * 60 * 24));
+            } else if (absDiff >= 1000 * 60 * 60) {
+                unit = 'hour';
+                value = Math.round(diff / (1000 * 60 * 60));
+            } else if (absDiff >= 1000 * 60) {
+                unit = 'minute';
+                value = Math.round(diff / (1000 * 60));
             }
 
-            const message = error?.message || fallbackMessage;
-            abp.notify.error(message);
+            return this.relativeTimeFormatter.format(value, unit);
         },
 
         resolveStatus(value) {
@@ -524,7 +798,7 @@
 
             if (typeof value === 'string') {
                 const normalized = value.trim();
-                return statusLabelMap[normalized] || statusLabelMap[normalized.toLowerCase()] || normalized;
+                return statusLabelMap[normalized] || statusLabelMap[normalized.toLowerCase?.()] || normalized;
             }
 
             if (typeof value === 'number') {
@@ -549,6 +823,34 @@
             }
 
             return 'Unknown';
+        },
+
+        resolveTypeValue(value) {
+            if (typeof value === 'string') {
+                const numeric = Number.parseInt(value, 10);
+                if (!Number.isNaN(numeric)) {
+                    return String(numeric);
+                }
+
+                switch (value.toLowerCase()) {
+                    case 'website':
+                        return '0';
+                    case 'api':
+                        return '1';
+                    case 'tcp':
+                        return '2';
+                    case 'redis':
+                        return '3';
+                    default:
+                        return '0';
+                }
+            }
+
+            if (typeof value === 'number') {
+                return String(value);
+            }
+
+            return '0';
         },
 
         formatDateTime(value) {
@@ -581,15 +883,9 @@
                 return '—';
             }
 
-            const hrs = Math.floor(seconds / 3600)
-                .toString()
-                .padStart(2, '0');
-            const mins = Math.floor((seconds % 3600) / 60)
-                .toString()
-                .padStart(2, '0');
-            const secs = Math.floor(seconds % 60)
-                .toString()
-                .padStart(2, '0');
+            const hrs = Math.floor(seconds / 3600).toString().padStart(2, '0');
+            const mins = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
+            const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
 
             return `${hrs}:${mins}:${secs}`;
         },
@@ -613,7 +909,7 @@
                 return fallback ?? 0;
             }
 
-            return parsed;
+            return Math.trunc(parsed);
         },
 
         normalizeString(value) {
@@ -623,18 +919,31 @@
 
             const trimmed = String(value).trim();
             return trimmed.length ? trimmed : null;
+        },
+
+        validateJson(str) {
+            if (!str) {
+                return true;
+            }
+
+            try {
+                JSON.parse(str);
+                return true;
+            } catch (error) {
+                return false;
+            }
         }
     };
 
     document.addEventListener('click', (event) => {
-        const target = event.target.closest('[data-action]');
-        if (!target) {
+        const actionEl = event.target.closest('[data-action]');
+        if (!actionEl || !window.monitoringTargets) {
             return;
         }
 
-        const action = target.getAttribute('data-action');
-        const id = target.getAttribute('data-id');
-        if (!action || !id || !window.monitoringTargets) {
+        const action = actionEl.getAttribute('data-action');
+        const id = actionEl.getAttribute('data-id');
+        if (!action || !id) {
             return;
         }
 

--- a/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
+++ b/src/Monitoring.Web/wwwroot/js/monitoring.targets.js
@@ -44,6 +44,18 @@
             this.manageForm = options.manageForm;
             this.manageErrors = options.manageErrors;
             this.manageSubmitButton = options.manageSubmitButton;
+            this.alertPolicyModalEl = options.alertPolicyModal;
+            this.alertPolicyForm = options.alertPolicyForm;
+            this.alertPolicyErrors = options.alertPolicyErrors;
+            this.alertPolicySubmit = options.alertPolicySubmit;
+            this.alertPolicyInheritance = options.alertPolicyInheritance;
+            this.maintenanceButton = options.maintenanceButton;
+            this.maintenanceModalEl = options.maintenanceModal;
+            this.maintenanceForm = options.maintenanceForm;
+            this.maintenanceErrors = options.maintenanceErrors;
+            this.maintenanceSubmit = options.maintenanceSubmit;
+            this.maintenanceTableBody = options.maintenanceTableBody;
+            this.maintenanceTargetSelect = options.maintenanceTargetSelect;
             this.pageInfo = options.pageInfo;
             this.prevButton = options.prevButton;
             this.nextButton = options.nextButton;
@@ -56,6 +68,8 @@
             this.searchDebounceHandle = null;
             this.formMode = 'create';
             this.editingTargetId = null;
+            this.alertPolicyTargetId = null;
+            this.maintenanceFilterTargetId = null;
 
             if (this.outagesModalEl) {
                 this.outagesModal = new bootstrap.Modal(this.outagesModalEl);
@@ -64,6 +78,16 @@
             if (this.manageModalEl) {
                 this.manageModal = new bootstrap.Modal(this.manageModalEl);
                 this.manageModalEl.addEventListener('hidden.bs.modal', () => this.resetForm());
+            }
+
+            if (this.alertPolicyModalEl) {
+                this.alertPolicyModal = new bootstrap.Modal(this.alertPolicyModalEl);
+                this.alertPolicyModalEl.addEventListener('hidden.bs.modal', () => this.resetAlertPolicyForm());
+            }
+
+            if (this.maintenanceModalEl) {
+                this.maintenanceModal = new bootstrap.Modal(this.maintenanceModalEl);
+                this.maintenanceModalEl.addEventListener('hidden.bs.modal', () => this.resetMaintenanceForm());
             }
 
             this.applyStateToControls();
@@ -156,6 +180,25 @@
 
             if (this.manageForm) {
                 this.manageForm.addEventListener('submit', (event) => this.submitManageForm(event));
+            }
+
+            if (this.alertPolicyForm) {
+                this.alertPolicyForm.addEventListener('submit', (event) => this.submitAlertPolicy(event));
+            }
+
+            if (this.maintenanceButton) {
+                this.maintenanceButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    this.openMaintenanceModal();
+                });
+            }
+
+            if (this.maintenanceForm) {
+                this.maintenanceForm.addEventListener('submit', (event) => this.submitMaintenance(event));
+            }
+
+            if (this.maintenanceTableBody) {
+                this.maintenanceTableBody.addEventListener('click', (event) => this.handleMaintenanceTableClick(event));
             }
 
             if (this.prevButton) {
@@ -259,6 +302,9 @@
             const statusClass = statusClassMap[status] || statusClassMap.Checking;
             const lastChecked = this.relativeTime(target.lastCheckedAt);
             const nextDue = this.relativeTime(target.nextDueAt);
+            const maintenanceIndicator = target.hasActiveMaintenance
+                ? '<span class="badge bg-warning text-dark ms-2" title="Under maintenance"><i class="fa fa-tools me-1"></i>Maintenance</span>'
+                : '';
 
             const actions = [];
 
@@ -269,6 +315,7 @@
             actions.push(`<button type="button" class="btn btn-outline-secondary btn-sm" data-action="outages" data-id="${target.id}" aria-label="View outages for ${this.escapeHtml(target.name)}"><i class="fa fa-bolt me-1" aria-hidden="true"></i>View outages</button>`);
 
             if (this.permissions.canEdit) {
+                actions.push(`<button type="button" class="btn btn-outline-warning btn-sm" data-action="policy" data-id="${target.id}" aria-label="Configure alert policy for ${this.escapeHtml(target.name)}"><i class="fa fa-bell me-1" aria-hidden="true"></i>Alert Policy</button>`);
                 actions.push(`<button type="button" class="btn btn-outline-info btn-sm" data-action="edit" data-id="${target.id}" aria-label="Edit ${this.escapeHtml(target.name)}"><i class="fa fa-pen me-1" aria-hidden="true"></i>Edit</button>`);
             }
 
@@ -285,7 +332,7 @@
                         <div class="d-flex justify-content-between align-items-start">
                             <div>
                                 <h5 class="mb-1">${escapedName}</h5>
-                                <span class="badge bg-light text-dark">${typeLabel}</span>
+                                <span class="badge bg-light text-dark">${typeLabel}</span>${maintenanceIndicator}
                             </div>
                         </div>
                         <div class="mt-3 small">
@@ -409,6 +456,309 @@
             if (this.manageForm) {
                 this.manageForm.reset();
             }
+        },
+
+        resetAlertPolicyForm() {
+            this.alertPolicyTargetId = null;
+            if (this.alertPolicyErrors) {
+                this.alertPolicyErrors.classList.add('d-none');
+                this.alertPolicyErrors.textContent = '';
+            }
+
+            if (this.alertPolicyForm) {
+                this.alertPolicyForm.reset();
+            }
+
+            if (this.alertPolicyInheritance) {
+                this.alertPolicyInheritance.textContent = '';
+            }
+
+            const titleEl = document.getElementById('monitoring-alert-policy-modal-title');
+            if (titleEl) {
+                titleEl.textContent = 'Alert policy';
+            }
+        },
+
+        showAlertPolicyError(message) {
+            if (!this.alertPolicyErrors) {
+                return;
+            }
+
+            if (message) {
+                this.alertPolicyErrors.classList.remove('d-none');
+                this.alertPolicyErrors.textContent = message;
+            } else {
+                this.alertPolicyErrors.classList.add('d-none');
+                this.alertPolicyErrors.textContent = '';
+            }
+        },
+
+        openAlertPolicy(id) {
+            if (!this.permissions.canEdit || !this.alertPolicyModal || !this.alertPolicyForm) {
+                return;
+            }
+
+            const target = this.targetCache.get(id);
+            if (!target) {
+                this.handleError(null, 'Unable to load the selected service. Please refresh and try again.');
+                return;
+            }
+
+            this.resetAlertPolicyForm();
+            this.alertPolicyTargetId = id;
+
+            const titleEl = document.getElementById('monitoring-alert-policy-modal-title');
+            if (titleEl) {
+                titleEl.textContent = `Alert policy · ${this.escapeHtml(target.name ?? '')}`;
+            }
+
+            this.toggleButtonState(this.alertPolicySubmit, true);
+            this.request(`/api/monitoring/targets/${id}/alert-policy`, { method: 'GET' })
+                .then((policy) => {
+                    this.populateAlertPolicyForm(policy);
+                    this.alertPolicyModal.show();
+                })
+                .catch((error) => this.showAlertPolicyError(this.extractErrorMessage(error) || 'Failed to load alert policy.'))
+                .finally(() => this.toggleButtonState(this.alertPolicySubmit, false));
+        },
+
+        populateAlertPolicyForm(policy) {
+            if (!this.alertPolicyForm) {
+                return;
+            }
+
+            const form = this.alertPolicyForm;
+            form.querySelector('#monitoring-alert-policy-target-id').value = policy?.targetId ?? '';
+            form.querySelector('#monitoring-alert-policy-enabled').checked = Boolean(policy?.enabled);
+            form.querySelector('#monitoring-alert-policy-notify-after').value = policy?.notifyAfterFailures ?? 1;
+            form.querySelector('#monitoring-alert-policy-repeat').value = policy?.repeatMinutes ?? 60;
+            form.querySelector('#monitoring-alert-policy-recover').value = policy?.recoverQuietMinutes ?? 10;
+            form.querySelector('#monitoring-alert-policy-channels').value = policy?.channelsJson ?? '';
+            form.querySelector('#monitoring-alert-policy-suppress').checked = Boolean(policy?.suppressDuringMaintenance);
+
+            if (this.alertPolicyInheritance) {
+                this.alertPolicyInheritance.textContent = policy?.isInherited
+                    ? 'Using global defaults.'
+                    : 'Custom policy for this service.';
+            }
+        },
+
+        submitAlertPolicy(event) {
+            event.preventDefault();
+            if (!this.alertPolicyForm || !this.alertPolicyTargetId) {
+                return;
+            }
+
+            const form = this.alertPolicyForm;
+            this.showAlertPolicyError(null);
+
+            const channelsValue = this.normalizeString(form.querySelector('#monitoring-alert-policy-channels').value);
+            if (channelsValue && !this.validateJson(channelsValue)) {
+                this.showAlertPolicyError('Channels JSON must be valid.');
+                return;
+            }
+
+            const payload = {
+                targetId: this.alertPolicyTargetId,
+                enabled: form.querySelector('#monitoring-alert-policy-enabled').checked,
+                notifyAfterFailures: this.toNumber(form.querySelector('#monitoring-alert-policy-notify-after').value, 1),
+                repeatMinutes: this.toNumber(form.querySelector('#monitoring-alert-policy-repeat').value, 60),
+                recoverQuietMinutes: this.toNumber(form.querySelector('#monitoring-alert-policy-recover').value, 10),
+                channelsJson: channelsValue,
+                suppressDuringMaintenance: form.querySelector('#monitoring-alert-policy-suppress').checked
+            };
+
+            this.toggleButtonState(this.alertPolicySubmit, true);
+            this.request(`/api/monitoring/targets/${this.alertPolicyTargetId}/alert-policy`, {
+                method: 'PUT',
+                body: payload
+            })
+                .then(() => {
+                    abp.notify.success('Alert policy saved.');
+                    if (this.alertPolicyModal) {
+                        this.alertPolicyModal.hide();
+                    }
+                })
+                .catch((error) => this.showAlertPolicyError(this.extractErrorMessage(error) || 'Failed to save alert policy.'))
+                .finally(() => this.toggleButtonState(this.alertPolicySubmit, false));
+        },
+
+        openMaintenanceModal(targetId = null) {
+            if (!this.permissions.canEdit || !this.maintenanceModal || !this.maintenanceForm) {
+                return;
+            }
+
+            this.maintenanceFilterTargetId = targetId;
+            this.resetMaintenanceForm();
+            this.populateMaintenanceTargets(targetId);
+            this.loadMaintenanceWindows(targetId);
+            this.maintenanceModal.show();
+        },
+
+        populateMaintenanceTargets(selectedId) {
+            if (!this.maintenanceTargetSelect) {
+                return;
+            }
+
+            const options = ['<option value="">All services (global)</option>'];
+            const entries = Array.from(this.targetCache.values()).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+            entries.forEach((target) => {
+                const selected = selectedId && target.id === selectedId ? ' selected' : '';
+                options.push(`<option value="${target.id}"${selected}>${this.escapeHtml(target.name ?? target.id)}</option>`);
+            });
+
+            this.maintenanceTargetSelect.innerHTML = options.join('');
+
+            if (selectedId) {
+                this.maintenanceTargetSelect.value = selectedId;
+            } else {
+                this.maintenanceTargetSelect.value = '';
+            }
+        },
+
+        resetMaintenanceForm() {
+            if (this.maintenanceErrors) {
+                this.maintenanceErrors.classList.add('d-none');
+                this.maintenanceErrors.textContent = '';
+            }
+
+            if (this.maintenanceForm) {
+                this.maintenanceForm.reset();
+            }
+        },
+
+        showMaintenanceError(message) {
+            if (!this.maintenanceErrors) {
+                return;
+            }
+
+            if (message) {
+                this.maintenanceErrors.classList.remove('d-none');
+                this.maintenanceErrors.textContent = message;
+            } else {
+                this.maintenanceErrors.classList.add('d-none');
+                this.maintenanceErrors.textContent = '';
+            }
+        },
+
+        loadMaintenanceWindows(targetId) {
+            const query = targetId ? `?targetId=${encodeURIComponent(targetId)}` : '';
+            this.request(`/api/monitoring/maintenance${query}`, { method: 'GET' })
+                .then((windows) => this.renderMaintenanceTable(Array.isArray(windows) ? windows : []))
+                .catch((error) => this.showMaintenanceError(this.extractErrorMessage(error) || 'Failed to load maintenance windows.'));
+        },
+
+        renderMaintenanceTable(windows) {
+            if (!this.maintenanceTableBody) {
+                return;
+            }
+
+            if (!windows.length) {
+                this.maintenanceTableBody.innerHTML = '<tr><td colspan="5" class="text-center text-muted">No maintenance windows scheduled.</td></tr>';
+                return;
+            }
+
+            const rows = windows.map((window) => {
+                const started = this.formatDateTime(window.startUtc);
+                const ended = this.formatDateTime(window.endUtc);
+                const targetName = window.targetId
+                    ? (this.targetCache.get(window.targetId)?.name ?? `Target ${window.targetId}`)
+                    : 'All services';
+                const reason = this.escapeHtml(window.reason ?? '—');
+                const deleteButton = this.permissions.canEdit
+                    ? `<button type="button" class="btn btn-link btn-sm text-danger" data-maintenance-action="delete" data-id="${window.id}"><i class="fa fa-trash me-1" aria-hidden="true"></i>Delete</button>`
+                    : '';
+
+                return `<tr>
+                    <td>${started}</td>
+                    <td>${ended}</td>
+                    <td>${this.escapeHtml(targetName)}</td>
+                    <td>${reason || '—'}</td>
+                    <td class="text-end">${deleteButton}</td>
+                </tr>`;
+            });
+
+            this.maintenanceTableBody.innerHTML = rows.join('');
+        },
+
+        submitMaintenance(event) {
+            event.preventDefault();
+            if (!this.maintenanceForm) {
+                return;
+            }
+
+            this.showMaintenanceError(null);
+
+            const targetIdValue = this.normalizeString(this.maintenanceTargetSelect?.value);
+            const startValue = this.normalizeString(this.maintenanceForm.querySelector('#monitoring-maintenance-start').value);
+            const endValue = this.normalizeString(this.maintenanceForm.querySelector('#monitoring-maintenance-end').value);
+            const reasonValue = this.normalizeString(this.maintenanceForm.querySelector('#monitoring-maintenance-reason').value);
+
+            if (!startValue || !endValue) {
+                this.showMaintenanceError('Start and end times are required.');
+                return;
+            }
+
+            const payload = {
+                targetId: targetIdValue || null,
+                startUtc: this.toIsoUtcString(startValue),
+                endUtc: this.toIsoUtcString(endValue),
+                reason: reasonValue
+            };
+
+            this.toggleButtonState(this.maintenanceSubmit, true);
+            this.request('/api/monitoring/maintenance', {
+                method: 'POST',
+                body: payload
+            })
+                .then(() => {
+                    abp.notify.success('Maintenance window scheduled.');
+                    this.resetMaintenanceForm();
+                    this.populateMaintenanceTargets(this.maintenanceFilterTargetId);
+                    this.loadMaintenanceWindows(this.maintenanceFilterTargetId);
+                    this.refresh(false);
+                })
+                .catch((error) => this.showMaintenanceError(this.extractErrorMessage(error) || 'Failed to create maintenance window.'))
+                .finally(() => this.toggleButtonState(this.maintenanceSubmit, false));
+        },
+
+        handleMaintenanceTableClick(event) {
+            const actionEl = event.target.closest('[data-maintenance-action]');
+            if (!actionEl) {
+                return;
+            }
+
+            const action = actionEl.getAttribute('data-maintenance-action');
+            const id = actionEl.getAttribute('data-id');
+            if (!action || !id) {
+                return;
+            }
+
+            if (action === 'delete') {
+                this.deleteMaintenance(id);
+            }
+        },
+
+        deleteMaintenance(id) {
+            if (!this.permissions.canEdit) {
+                return;
+            }
+
+            abp.message.confirm('Delete this maintenance window?')
+                .then((confirmed) => {
+                    if (!confirmed) {
+                        return;
+                    }
+
+                    this.request(`/api/monitoring/maintenance/${id}`, { method: 'DELETE' })
+                        .then(() => {
+                            abp.notify.info('Maintenance window removed.');
+                            this.loadMaintenanceWindows(this.maintenanceFilterTargetId);
+                            this.refresh(false);
+                        })
+                        .catch((error) => this.showMaintenanceError(this.extractErrorMessage(error) || 'Failed to delete maintenance window.'));
+                });
         },
 
         setFormTitle(title) {
@@ -921,6 +1271,27 @@
             return trimmed.length ? trimmed : null;
         },
 
+        toIsoUtcString(value) {
+            const normalized = this.normalizeString(value);
+            if (!normalized) {
+                return null;
+            }
+
+            if (normalized.endsWith('Z')) {
+                return normalized;
+            }
+
+            if (normalized.length === 16) { // YYYY-MM-DDTHH:mm
+                return `${normalized}:00Z`;
+            }
+
+            if (normalized.length === 19) { // YYYY-MM-DDTHH:mm:ss
+                return `${normalized}Z`;
+            }
+
+            return `${normalized}Z`;
+        },
+
         validateJson(str) {
             if (!str) {
                 return true;
@@ -953,6 +1324,9 @@
                 break;
             case 'outages':
                 window.monitoringTargets.showOutages(id);
+                break;
+            case 'policy':
+                window.monitoringTargets.openAlertPolicy(id);
                 break;
             case 'edit':
                 window.monitoringTargets.openEdit(id);

--- a/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
+++ b/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
@@ -12,12 +12,14 @@
     <ProjectReference Include="..\..\src\HRSDataIntegration.Application\HRSDataIntegration.Application.csproj" />
     <ProjectReference Include="..\..\src\Monitoring.Application\Monitoring.Application.csproj" />
     <ProjectReference Include="..\..\src\Monitoring.Domain\Monitoring.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Monitoring.HttpApi\Monitoring.HttpApi.csproj" />
     <ProjectReference Include="..\HRSDataIntegration.Domain.Tests\HRSDataIntegration.Domain.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
+++ b/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 

--- a/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
+++ b/test/HRSDataIntegration.Application.Tests/HRSDataIntegration.Application.Tests.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\HRSDataIntegration.Application\HRSDataIntegration.Application.csproj" />
+    <ProjectReference Include="..\..\src\Monitoring.Application\Monitoring.Application.csproj" />
+    <ProjectReference Include="..\..\src\Monitoring.Domain\Monitoring.Domain.csproj" />
     <ProjectReference Include="..\HRSDataIntegration.Domain.Tests\HRSDataIntegration.Domain.Tests.csproj" />
   </ItemGroup>
 

--- a/test/HRSDataIntegration.Application.Tests/Monitoring/AlertEvaluatorTests.cs
+++ b/test/HRSDataIntegration.Application.Tests/Monitoring/AlertEvaluatorTests.cs
@@ -1,0 +1,159 @@
+using System;
+using Monitoring.Alerts;
+using Monitoring.Targets;
+using Xunit;
+
+namespace HRSDataIntegration.Monitoring;
+
+public class AlertEvaluatorTests
+{
+    [Fact]
+    public void Down_alert_triggers_after_threshold()
+    {
+        var targetId = Guid.NewGuid();
+        var outage = new OutageWindow(Guid.NewGuid(), targetId, DateTime.UtcNow.AddMinutes(-5), 1);
+
+        var inputBelow = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Online,
+            currentStatus: ServiceStatus.Offline,
+            consecutiveFailures: 2,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 3,
+            repeatMinutes: 60,
+            recoverQuietMinutes: 10,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: outage,
+            closedOutage: null,
+            previousLastUpAt: DateTime.UtcNow.AddMinutes(-30));
+
+        var resultBelow = AlertEvaluator.Evaluate(inputBelow);
+        Assert.Null(resultBelow.EventType);
+
+        var inputThreshold = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Online,
+            currentStatus: ServiceStatus.Offline,
+            consecutiveFailures: 3,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 3,
+            repeatMinutes: 60,
+            recoverQuietMinutes: 10,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: outage,
+            closedOutage: null,
+            previousLastUpAt: DateTime.UtcNow.AddMinutes(-30));
+
+        var resultThreshold = AlertEvaluator.Evaluate(inputThreshold);
+        Assert.Equal(AlertEventType.Down, resultThreshold.EventType);
+        Assert.True(resultThreshold.ShouldRecordAlert);
+    }
+
+    [Fact]
+    public void Still_down_repeats_after_interval()
+    {
+        var targetId = Guid.NewGuid();
+        var outage = new OutageWindow(Guid.NewGuid(), targetId, DateTime.UtcNow.AddHours(-2), 1);
+        outage.RecordAlert(DateTime.UtcNow.AddMinutes(-30));
+
+        var inputTooSoon = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Offline,
+            currentStatus: ServiceStatus.Offline,
+            consecutiveFailures: 5,
+            timestamp: DateTime.UtcNow.AddMinutes(-10),
+            notifyAfterFailures: 1,
+            repeatMinutes: 30,
+            recoverQuietMinutes: 10,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: outage,
+            closedOutage: null,
+            previousLastUpAt: DateTime.UtcNow.AddHours(-3));
+
+        var resultTooSoon = AlertEvaluator.Evaluate(inputTooSoon);
+        Assert.Null(resultTooSoon.EventType);
+
+        var inputDue = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Offline,
+            currentStatus: ServiceStatus.Offline,
+            consecutiveFailures: 6,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 1,
+            repeatMinutes: 30,
+            recoverQuietMinutes: 10,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: outage,
+            closedOutage: null,
+            previousLastUpAt: DateTime.UtcNow.AddHours(-3));
+
+        var resultDue = AlertEvaluator.Evaluate(inputDue);
+        Assert.Equal(AlertEventType.StillDown, resultDue.EventType);
+        Assert.True(resultDue.ShouldRecordAlert);
+    }
+
+    [Fact]
+    public void Recovered_alert_respects_quiet_minutes()
+    {
+        var outage = new OutageWindow(Guid.NewGuid(), Guid.NewGuid(), DateTime.UtcNow.AddHours(-1), 1);
+        outage.RecordAlert(DateTime.UtcNow.AddMinutes(-30));
+
+        var inputTooSoon = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Offline,
+            currentStatus: ServiceStatus.Online,
+            consecutiveFailures: 0,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 1,
+            repeatMinutes: 60,
+            recoverQuietMinutes: 30,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: null,
+            closedOutage: outage,
+            previousLastUpAt: DateTime.UtcNow.AddMinutes(-15));
+
+        var resultTooSoon = AlertEvaluator.Evaluate(inputTooSoon);
+        Assert.Null(resultTooSoon.EventType);
+
+        var inputQuietMet = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Offline,
+            currentStatus: ServiceStatus.Online,
+            consecutiveFailures: 0,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 1,
+            repeatMinutes: 60,
+            recoverQuietMinutes: 30,
+            enabled: true,
+            underMaintenance: false,
+            activeOutage: null,
+            closedOutage: outage,
+            previousLastUpAt: DateTime.UtcNow.AddMinutes(-45));
+
+        var resultQuietMet = AlertEvaluator.Evaluate(inputQuietMet);
+        Assert.Equal(AlertEventType.Recovered, resultQuietMet.EventType);
+        Assert.False(resultQuietMet.ShouldRecordAlert);
+    }
+
+    [Fact]
+    public void Maintenance_suppresses_alerts()
+    {
+        var outage = new OutageWindow(Guid.NewGuid(), Guid.NewGuid(), DateTime.UtcNow.AddMinutes(-5), 1);
+
+        var input = new AlertEvaluationInput(
+            previousStatus: ServiceStatus.Online,
+            currentStatus: ServiceStatus.Offline,
+            consecutiveFailures: 5,
+            timestamp: DateTime.UtcNow,
+            notifyAfterFailures: 1,
+            repeatMinutes: 60,
+            recoverQuietMinutes: 10,
+            enabled: true,
+            underMaintenance: true,
+            activeOutage: outage,
+            closedOutage: null,
+            previousLastUpAt: DateTime.UtcNow.AddHours(-1));
+
+        var result = AlertEvaluator.Evaluate(input);
+        Assert.Null(result.EventType);
+    }
+}

--- a/test/HRSDataIntegration.Application.Tests/Monitoring/DashboardExportControllerTests.cs
+++ b/test/HRSDataIntegration.Application.Tests/Monitoring/DashboardExportControllerTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Monitoring.Controllers;
+using Monitoring.Dashboard;
+using Monitoring.Targets;
+using Xunit;
+
+namespace HRSDataIntegration.Monitoring;
+
+public class DashboardExportControllerTests
+{
+    [Fact]
+    public async Task Export_uptime_generates_csv()
+    {
+        var service = new FakeDashboardAppService();
+        var controller = new MonitoringExportController(service);
+
+        var result = await controller.ExportUptimeAsync(Guid.NewGuid(), DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, "day");
+
+        Assert.Equal("text/csv", result.ContentType);
+        var content = Encoding.UTF8.GetString(result.FileContents);
+        Assert.StartsWith("start,end,uptimePercentage", content);
+        Assert.Contains("100", content);
+    }
+
+    [Fact]
+    public async Task Export_incidents_generates_csv()
+    {
+        var service = new FakeDashboardAppService();
+        var controller = new MonitoringExportController(service);
+
+        var result = await controller.ExportIncidentsAsync(Guid.NewGuid(), DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
+
+        Assert.Equal("text/csv", result.ContentType);
+        var content = Encoding.UTF8.GetString(result.FileContents);
+        Assert.Contains("durationSeconds", content);
+        Assert.Contains("failureCount", content);
+    }
+
+    private sealed class FakeDashboardAppService : IDashboardAppService
+    {
+        public Task<List<DashboardIncidentDto>> GetIncidentsAsync(Guid targetId, DateTime from, DateTime to, int skip = 0, int max = 100)
+        {
+            return Task.FromResult(new List<DashboardIncidentDto>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TargetId = targetId,
+                    StartedAt = from,
+                    EndedAt = from.AddMinutes(5),
+                    FailureCount = 3,
+                    TotalDurationSec = 300
+                }
+            });
+        }
+
+        public Task<MttrMtbfDto> GetReliabilityAsync(DateTime from, DateTime to, ServiceType? filterType = null)
+        {
+            return Task.FromResult(new MttrMtbfDto());
+        }
+
+        public Task<DashboardSummaryDto> GetSummaryAsync(DateTime from, DateTime to, ServiceType? filterType = null)
+        {
+            return Task.FromResult(new DashboardSummaryDto());
+        }
+
+        public Task<List<UptimeBucketDto>> GetUptimeSeriesAsync(Guid targetId, DateTime from, DateTime to, string bucket = "day")
+        {
+            return Task.FromResult(new List<UptimeBucketDto>
+            {
+                new()
+                {
+                    Start = from,
+                    End = to,
+                    UptimePercentage = 100
+                }
+            });
+        }
+    }
+}

--- a/test/HRSDataIntegration.Application.Tests/Monitoring/DashboardMetricsHelperTests.cs
+++ b/test/HRSDataIntegration.Application.Tests/Monitoring/DashboardMetricsHelperTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Monitoring.Dashboard;
+using Monitoring.Targets;
+using Xunit;
+
+namespace HRSDataIntegration.Monitoring;
+
+public class DashboardMetricsHelperTests
+{
+    [Fact]
+    public void Calculates_overlap_for_partial_window()
+    {
+        var outage = new OutageWindow(Guid.NewGuid(), Guid.NewGuid(), new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc), 1);
+        outage.Close(new DateTime(2024, 6, 1, 2, 0, 0, DateTimeKind.Utc));
+
+        var overlap = DashboardMetricsHelper.CalculateOverlapSeconds(
+            outage,
+            new DateTime(2024, 6, 1, 1, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 1, 3, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal(3600, overlap);
+    }
+
+    [Fact]
+    public void Calculates_mttr_in_seconds()
+    {
+        var outage = new OutageWindow(Guid.NewGuid(), Guid.NewGuid(), new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc), 1);
+        outage.Close(new DateTime(2024, 6, 1, 0, 45, 0, DateTimeKind.Utc));
+
+        var mttr = DashboardMetricsHelper.CalculateMttrSeconds(
+            new List<OutageWindow> { outage },
+            new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 6, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal(2700, mttr);
+    }
+
+    [Fact]
+    public void Calculates_mtbf_gaps_between_outages()
+    {
+        var targetId = Guid.NewGuid();
+        var first = new OutageWindow(Guid.NewGuid(), targetId, new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc), 1);
+        first.Close(new DateTime(2024, 6, 1, 0, 10, 0, DateTimeKind.Utc));
+        var second = new OutageWindow(Guid.NewGuid(), targetId, new DateTime(2024, 6, 1, 1, 0, 0, DateTimeKind.Utc), 1);
+        second.Close(new DateTime(2024, 6, 1, 1, 10, 0, DateTimeKind.Utc));
+
+        var gaps = DashboardMetricsHelper.CalculateMtbfSeconds(new List<OutageWindow> { second, first });
+
+        Assert.Single(gaps);
+        Assert.Equal(3000, gaps[0]);
+    }
+}

--- a/test/HRSDataIntegration.Application.Tests/Monitoring/NotificationChannelTests.cs
+++ b/test/HRSDataIntegration.Application.Tests/Monitoring/NotificationChannelTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Monitoring.Alerts;
+using Monitoring.Targets;
+using Xunit;
+
+namespace HRSDataIntegration.Monitoring;
+
+public class NotificationChannelTests
+{
+    [Fact]
+    public async Task Webhook_channel_posts_expected_payload()
+    {
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var builder = new WebHostBuilder()
+            .ConfigureServices(_ => { })
+            .Configure(app =>
+            {
+                app.Run(async context =>
+                {
+                    using var reader = new System.IO.StreamReader(context.Request.Body);
+                    var body = await reader.ReadToEndAsync();
+                    tcs.TrySetResult(body);
+                    context.Response.StatusCode = 200;
+                    await context.Response.CompleteAsync();
+                });
+            });
+
+        using var server = new TestServer(builder);
+        using var client = server.CreateClient();
+        var factory = new TestHttpClientFactory(client);
+
+        var channel = new WebhookNotificationChannel(
+            factory,
+            NullLoggerFactory.Instance.CreateLogger<WebhookNotificationChannel>(),
+            new List<string> { server.BaseAddress.ToString() },
+            new Dictionary<string, string>());
+
+        var snapshot = new TargetSnapshot(
+            Guid.NewGuid(),
+            "Web API",
+            ServiceType.Api,
+            "https://api.example.com/health",
+            ServiceStatus.Offline,
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            DateTime.UtcNow.AddMinutes(-5),
+            null,
+            null);
+
+        var payload = new AlertPayload(
+            AlertEventType.Down,
+            DateTime.UtcNow,
+            "Timeout",
+            123,
+            null);
+
+        await channel.SendAsync(snapshot, payload, CancellationToken.None);
+
+        var body = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        Assert.Equal("Down", root.GetProperty("eventType").GetString());
+        var target = root.GetProperty("target");
+        Assert.Equal(snapshot.TargetId.ToString(), target.GetProperty("id").GetString());
+        Assert.Equal("Offline", target.GetProperty("status").GetString());
+        var details = root.GetProperty("details");
+        Assert.Equal("Timeout", details.GetProperty("errorSummary").GetString());
+        Assert.Equal(123, details.GetProperty("responseTimeMs").GetInt32());
+    }
+
+    [Fact]
+    public async Task Telegram_channel_skips_without_configuration()
+    {
+        var factory = new TestHttpClientFactory(new HttpClient(new HttpClientHandler()));
+        var channel = new TelegramNotificationChannel(
+            factory,
+            NullLoggerFactory.Instance.CreateLogger<TelegramNotificationChannel>(),
+            string.Empty,
+            Array.Empty<string>());
+
+        var snapshot = new TargetSnapshot(
+            Guid.NewGuid(),
+            "Redis",
+            ServiceType.Redis,
+            "redis:6379",
+            ServiceStatus.Online,
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            null,
+            DateTime.UtcNow,
+            null);
+
+        var payload = new AlertPayload(AlertEventType.Recovered, DateTime.UtcNow, null, null, null);
+
+        await channel.SendAsync(snapshot, payload, CancellationToken.None);
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public TestHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return _client;
+        }
+    }
+}

--- a/test/HRSDataIntegration.Application.Tests/Monitoring/NotificationChannelTests.cs
+++ b/test/HRSDataIntegration.Application.Tests/Monitoring/NotificationChannelTests.cs
@@ -42,7 +42,7 @@ public class NotificationChannelTests
 
         var channel = new WebhookNotificationChannel(
             factory,
-            NullLoggerFactory.Instance.CreateLogger<WebhookNotificationChannel>(),
+            NullLogger<WebhookNotificationChannel>.Instance,
             new List<string> { server.BaseAddress.ToString() },
             new Dictionary<string, string>());
 
@@ -86,7 +86,7 @@ public class NotificationChannelTests
         var factory = new TestHttpClientFactory(new HttpClient(new HttpClientHandler()));
         var channel = new TelegramNotificationChannel(
             factory,
-            NullLoggerFactory.Instance.CreateLogger<TelegramNotificationChannel>(),
+            NullLogger<TelegramNotificationChannel>.Instance,
             string.Empty,
             Array.Empty<string>());
 


### PR DESCRIPTION
## Summary
- register the monitoring background worker during service configuration and fix the module initialization signature
- centralize monitoring target status updates in a shared processor so the worker and APIs reuse the same logic
- expose CheckNow and CheckAll application service endpoints that execute health checks immediately and return result DTOs
- fix Redis sentinel discovery and TCP endpoint parsing with a shared host/port helper to unblock compilation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce64c0ef808324adcf7e6baeb8e565